### PR TITLE
feat(cd): Deploy apps/api to Azure Functions in the CD pipeline

### DIFF
--- a/.github/workflows/on-pull-request-main.yml
+++ b/.github/workflows/on-pull-request-main.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   actions: read
   contents: read
+  id-token: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   actions: read
   contents: read
+  id-token: write
 
 jobs:
   ci-staging:

--- a/.github/workflows/reusable-cd.yml
+++ b/.github/workflows/reusable-cd.yml
@@ -89,6 +89,50 @@ jobs:
           supabase secrets set APP_URL=${{ vars.APP_URL }}
           supabase functions deploy
 
+  backend-api:
+    name: Deploy API to Azure Functions
+    needs: [database]
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: |
+          pnpm install --frozen-lockfile
+
+      - name: Build deployment package
+        run: |
+          pnpm --filter @txg/api build:deploy
+
+      - name: Log in to Azure via OIDC
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Deploy to Azure Functions
+        uses: Azure/functions-action@v1
+        with:
+          app-name: ${{ vars.AZURE_FUNCTIONAPP_NAME }}
+          package: apps/api/deploy
+          remote-build: true
+          sku: flexconsumption
+
   frontend:
     name: Deploy Angular application to Azure Static Web App
     needs: [backend]

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # Compiled output
 dist/
+apps/api/deploy/
 /tmp
 out-tsc/
 /bazel-out

--- a/apps/api/pack.mjs
+++ b/apps/api/pack.mjs
@@ -5,14 +5,18 @@ import { cp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 // @azure/functions. Everything else is bundled into dist/main.js by esbuild,
 // and the full package.json cannot be deployed as-is: its workspace:* protocol
 // is not resolvable by the plain npm install that runs during remote build.
-const pkg = JSON.parse(await readFile('package.json', 'utf8'));
+// Resolve everything relative to this script, not the working directory, so
+// the assembly (including the rm -rf) is safe no matter where it is run from.
+const here = (path) => new URL(path, import.meta.url);
 
-await rm('deploy', { recursive: true, force: true });
-await mkdir('deploy');
-await cp('host.json', 'deploy/host.json');
-await cp('dist', 'deploy/dist', { recursive: true });
+const pkg = JSON.parse(await readFile(here('package.json'), 'utf8'));
+
+await rm(here('deploy'), { recursive: true, force: true });
+await mkdir(here('deploy'));
+await cp(here('host.json'), here('deploy/host.json'));
+await cp(here('dist'), here('deploy/dist'), { recursive: true });
 await writeFile(
-  'deploy/package.json',
+  here('deploy/package.json'),
   JSON.stringify(
     {
       name: pkg.name,

--- a/apps/api/pack.mjs
+++ b/apps/api/pack.mjs
@@ -1,0 +1,30 @@
+import { cp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+
+// Assemble the self-contained Azure Functions deployment package in deploy/:
+// host.json + dist/ + a minimal package.json whose only dependency is
+// @azure/functions. Everything else is bundled into dist/main.js by esbuild,
+// and the full package.json cannot be deployed as-is: its workspace:* protocol
+// is not resolvable by the plain npm install that runs during remote build.
+const pkg = JSON.parse(await readFile('package.json', 'utf8'));
+
+await rm('deploy', { recursive: true, force: true });
+await mkdir('deploy');
+await cp('host.json', 'deploy/host.json');
+await cp('dist', 'deploy/dist', { recursive: true });
+await writeFile(
+  'deploy/package.json',
+  JSON.stringify(
+    {
+      name: pkg.name,
+      version: pkg.version,
+      main: pkg.main,
+      dependencies: {
+        '@azure/functions': pkg.dependencies['@azure/functions'],
+      },
+    },
+    null,
+    2
+  ) + '\n'
+);
+
+console.log('Deployment package assembled in deploy/');

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,6 +6,7 @@
   "main": "dist/main.js",
   "scripts": {
     "build": "node esbuild.mjs",
+    "build:deploy": "pnpm build && node pack.mjs",
     "typecheck": "tsc --noEmit",
     "start": "pnpm build && func start",
     "lint": "eslint \"src/**/*.ts\"",


### PR DESCRIPTION
## Summary

Phase 5 of the Azure migration: the CD pipeline now deploys `apps/api` to the Azure Function Apps (`func-10xgains-staging` / `func-10xgains-prod`, Flex Consumption) on every staging/production deployment. The Supabase Edge Functions deployment stays untouched and continues to serve all user traffic until the Phase 6 frontend cutover.

## Changes

- **`apps/api/pack.mjs`** (+ `build:deploy` script): assembles a self-contained deployment package in `apps/api/deploy/` — `host.json`, the esbuild bundle, and a *generated minimal* `package.json` whose only dependency is `@azure/functions`. The app's real `package.json` cannot be deployed: its `workspace:*` dependency is not resolvable by the plain `npm install` that runs during Azure's remote build.
- **`reusable-cd.yml`**: new `backend-api` job (parallel to the edge-functions `backend` job, after `database`): pnpm install → `build:deploy` → `azure/login@v2` (OIDC) → `Azure/functions-action@v1` (`remote-build: true`, `sku: flexconsumption`).
- **`on-pull-request-main.yml` / `on-release.yml`**: grant `id-token: write` — required for OIDC federation; job-level permissions in a reusable workflow cannot exceed the caller's grant.
- **`.gitignore`**: `apps/api/deploy/`.

## Verification

The exact deployment package was exercised locally end-to-end, simulating what Azure runs after remote build (`npm install` against the minimal manifest, host loading `dist/main.js` from a folder containing only the shipped files):

- Host registers exactly one function: `api: [GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD] /api/{*path}`
- `GET /api/health` → 200 JSON
- `GET /api/plans` unauthenticated → clean 401 envelope (`AUTH_REQUIRED`)
- `OPTIONS /api/plans` preflight → 204 with Hono CORS headers
- Unknown route → 404
- `build:deploy` rerun wipes stale files (including `local.settings.json` and `node_modules`) and reassembles exactly `host.json` + `package.json` + `dist/`

The first real Azure deploy happens in this PR's own staging CD run — verify with `az functionapp function list -g rg-10xgains-staging -n func-10xgains-staging` and `curl https://func-10xgains-staging.azurewebsites.net/api/health` after approving the deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)