### PR TITLE
feat(web): Switch frontend to the Azure Functions API

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -118,6 +118,7 @@ jobs:
             -e "s|__BUILD_NAME__|${{ inputs.build_name }}|g" \
             -e "s|__BUILD_SHA__|${{ inputs.build_sha }}|g" \
             -e "s|__BUILD_TAG__|${{ inputs.build_tag }}|g" \
+            -e "s|__API_URL__|${{ vars.API_URL }}|g" \
             -e "s|__SUPABASE_URL__|${{ vars.SUPABASE_URL }}|g" \
             -e "s|__SUPABASE_ANON_KEY__|${{ secrets.SUPABASE_ANON_KEY }}|g" \
             "$OUTPUT_FILE"

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@
     ```typescript
     export const environment = {
       production: false,
+      api: {
+        url: 'http://localhost:7071', // The local Azure Functions host (pnpm --filter @txg/api start)
+      },
       supabase: {
         url: 'YOUR_LOCAL_SUPABASE_URL', // e.g., http://localhost:54321
         key: 'YOUR_LOCAL_SUPABASE_ANON_KEY', // The long JWT string

--- a/apps/web/src/app/shared/api/api.service.spec.ts
+++ b/apps/web/src/app/shared/api/api.service.spec.ts
@@ -1,0 +1,111 @@
+import { TestBed } from '@angular/core/testing';
+import { firstValueFrom } from 'rxjs';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ApiService } from './api.service';
+import { SupabaseService } from '../db/supabase.service';
+import { EnvironmentService } from '../services/environment.service';
+
+const API_URL = 'https://func-test.azurewebsites.net';
+const ACCESS_TOKEN = 'test-access-token';
+
+describe('ApiService', () => {
+  let service: ApiService;
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let getSessionMock: ReturnType<typeof vi.fn>;
+
+  const mockJsonResponse = (status: number, body: unknown) =>
+    new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+
+  beforeEach(() => {
+    getSessionMock = vi.fn().mockResolvedValue({ data: { session: { access_token: ACCESS_TOKEN } } });
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    TestBed.configureTestingModule({
+      providers: [
+        ApiService,
+        { provide: SupabaseService, useValue: { client: { auth: { getSession: getSessionMock } } } },
+        { provide: EnvironmentService, useValue: { apiUrl: API_URL } },
+      ]
+    });
+    service = TestBed.inject(ApiService);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('should GET from the configured API URL with a Bearer token', async () => {
+    fetchMock.mockResolvedValue(mockJsonResponse(200, { data: [{ id: '1' }], totalCount: 1 }));
+
+    const result = await firstValueFrom(service.get<{ id: string }[]>('/plans?limit=10'));
+
+    expect(fetchMock).toHaveBeenCalledWith(`${API_URL}/api/plans?limit=10`, {
+      method: 'GET',
+      headers: { 'Authorization': `Bearer ${ACCESS_TOKEN}` },
+      body: undefined,
+    });
+    expect(result).toEqual({ data: [{ id: '1' }], totalCount: 1, error: null });
+  });
+
+  it('should omit the Authorization header when there is no session', async () => {
+    getSessionMock.mockResolvedValue({ data: { session: null } });
+    fetchMock.mockResolvedValue(mockJsonResponse(200, { data: null }));
+
+    await firstValueFrom(service.get('/health'));
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers).not.toHaveProperty('Authorization');
+    expect(init).not.toHaveProperty('credentials');
+  });
+
+  it('should POST a JSON body with Content-Type header', async () => {
+    fetchMock.mockResolvedValue(mockJsonResponse(201, { data: { id: '2' } }));
+
+    const result = await firstValueFrom(service.post('/plans', { name: 'My plan' }));
+
+    expect(fetchMock).toHaveBeenCalledWith(`${API_URL}/api/plans`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${ACCESS_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ name: 'My plan' }),
+    });
+    expect(result).toEqual({ data: { id: '2' }, totalCount: undefined, error: null });
+  });
+
+  it('should resolve 204 responses as { data: null, error: null } without parsing the body', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 204 }));
+
+    const result = await firstValueFrom(service.delete('/plans/some-id/days/day-id'));
+
+    expect(result).toEqual({ data: null, error: null });
+  });
+
+  it('should resolve 404 responses as { data: null, error: null }', async () => {
+    fetchMock.mockResolvedValue(mockJsonResponse(404, { error: 'Not found', status: 404 }));
+
+    const result = await firstValueFrom(service.get('/plans/missing-id'));
+
+    expect(result).toEqual({ data: null, error: null });
+  });
+
+  it('should throw the envelope error message on non-2xx responses', async () => {
+    fetchMock.mockResolvedValue(mockJsonResponse(400, { error: 'Invalid request body', status: 400 }));
+
+    await expect(firstValueFrom(service.post('/plans', {}))).rejects.toThrow('Invalid request body');
+  });
+
+  it('should throw a generic message when the error body is not JSON', async () => {
+    fetchMock.mockResolvedValue(new Response('Bad Gateway', { status: 502 }));
+
+    await expect(firstValueFrom(service.get('/plans'))).rejects.toThrow('Request failed with status 502');
+  });
+
+  it('should propagate network errors', async () => {
+    fetchMock.mockRejectedValue(new TypeError('Failed to fetch'));
+
+    await expect(firstValueFrom(service.get('/plans'))).rejects.toThrow('Failed to fetch');
+  });
+});

--- a/apps/web/src/app/shared/api/api.service.spec.ts
+++ b/apps/web/src/app/shared/api/api.service.spec.ts
@@ -75,6 +75,31 @@ describe('ApiService', () => {
     expect(result).toEqual({ data: { id: '2' }, totalCount: undefined, error: null });
   });
 
+  it('should resolve responses without a data property as { data: null }', async () => {
+    fetchMock.mockResolvedValue(mockJsonResponse(200, { message: 'OK' }));
+
+    const result = await firstValueFrom(service.get('/plans'));
+
+    expect(result).toEqual({ data: null, totalCount: undefined, error: null });
+  });
+
+  it('should not duplicate slashes when the API URL has a trailing slash', async () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        ApiService,
+        { provide: SupabaseService, useValue: { client: { auth: { getSession: getSessionMock } } } },
+        { provide: EnvironmentService, useValue: { apiUrl: `${API_URL}/` } },
+      ]
+    });
+    service = TestBed.inject(ApiService);
+    fetchMock.mockResolvedValue(mockJsonResponse(200, { data: [] }));
+
+    await firstValueFrom(service.get('/plans'));
+
+    expect(fetchMock.mock.calls[0][0]).toBe(`${API_URL}/api/plans`);
+  });
+
   it('should resolve 204 responses as { data: null, error: null } without parsing the body', async () => {
     fetchMock.mockResolvedValue(new Response(null, { status: 204 }));
 

--- a/apps/web/src/app/shared/api/api.service.ts
+++ b/apps/web/src/app/shared/api/api.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable, from } from 'rxjs';
-import { handleNotFoundHttpError, SupabaseService } from '../db/supabase.service';
+import { SupabaseService } from '../db/supabase.service';
+import { EnvironmentService } from '../services/environment.service';
 
 export interface ApiServiceResponse<T> {
   data: T | null;
@@ -8,7 +9,6 @@ export interface ApiServiceResponse<T> {
   error: string | null;
 }
 
-type ApiInternalResponse<T> = ApiInternalSuccessResponse<T> | ApiInternalErrorResponse;
 interface ApiInternalSuccessResponse<T> { data: T; totalCount?: number; message?: string; }
 interface ApiInternalErrorResponse { error: string; details?: Record<string, unknown>; code?: string; }
 
@@ -17,42 +17,62 @@ interface ApiInternalErrorResponse { error: string; details?: Record<string, unk
 })
 export class ApiService {
   private supabaseService = inject(SupabaseService);
+  private environmentService = inject(EnvironmentService);
 
   public get<T>(url: string): Observable<ApiServiceResponse<T>> {
-    const promise = this.supabaseService.client.functions.invoke<ApiInternalResponse<T>>(this.formatApiUrl(url), { method: 'GET' });
-    return from(promise.then(this.handleFunctionResponse));
+    return from(this.request<T>('GET', url));
   }
 
   public post<TReq extends Record<string, unknown>, T>(url: string, body: TReq): Observable<ApiServiceResponse<T>> {
-    const promise = this.supabaseService.client.functions.invoke<ApiInternalResponse<T>>(this.formatApiUrl(url), { method: 'POST', body: body });
-    return from(promise.then(this.handleFunctionResponse));
+    return from(this.request<T>('POST', url, body));
   }
 
   public put<TReq extends Record<string, unknown>, T>(url: string, body: TReq): Observable<ApiServiceResponse<T>> {
-    const promise = this.supabaseService.client.functions.invoke<ApiInternalResponse<T>>(this.formatApiUrl(url), { method: 'PUT', body: body });
-    return from(promise.then(this.handleFunctionResponse));
+    return from(this.request<T>('PUT', url, body));
   }
 
   public delete(url: string): Observable<ApiServiceResponse<null>> {
-    const promise = this.supabaseService.client.functions.invoke<ApiInternalResponse<null>>(this.formatApiUrl(url), { method: 'DELETE' });
-    return from(promise.then(this.handleFunctionResponse));
+    return from(this.request<null>('DELETE', url));
   }
 
   public patch<TReq extends Record<string, unknown>, T>(url: string, body: TReq): Observable<ApiServiceResponse<T>> {
-    const promise = this.supabaseService.client.functions.invoke<ApiInternalResponse<T>>(this.formatApiUrl(url), { method: 'PATCH', body: body });
-    return from(promise.then(this.handleFunctionResponse));
+    return from(this.request<T>('PATCH', url, body));
+  }
+
+  private async request<T>(method: string, url: string, body?: Record<string, unknown>): Promise<ApiServiceResponse<T>> {
+    const headers: Record<string, string> = {};
+
+    // getSession() refreshes an expired access token before returning it.
+    const { data: { session } } = await this.supabaseService.client.auth.getSession();
+    if (session) {
+      headers['Authorization'] = `Bearer ${session.access_token}`;
+    }
+    if (body !== undefined) {
+      headers['Content-Type'] = 'application/json';
+    }
+
+    // No `credentials` option: the API authenticates via the Authorization
+    // header, and its platform CORS is configured without credential support.
+    const response = await fetch(this.formatApiUrl(url), {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+
+    if (response.status === 404 || response.status === 204) {
+      return { data: null, error: null };
+    }
+
+    if (!response.ok) {
+      const errorResponse = await response.json().catch(() => null) as ApiInternalErrorResponse | null;
+      throw new Error(errorResponse?.error ?? `Request failed with status ${response.status}`);
+    }
+
+    const successResponse = await response.json() as ApiInternalSuccessResponse<T>;
+    return { data: successResponse.data, totalCount: successResponse.totalCount, error: null };
   }
 
   private formatApiUrl(url: string): string {
-    return 'api/' + url.replace(/^\/+|\/+$/g, "");
-  }
-
-  private async handleFunctionResponse<T>(response: { data: ApiInternalResponse<T> | null; error: Error | null }): Promise<ApiServiceResponse<T>> {
-    if (!response.error) {
-      const successResponse = response.data as ApiInternalSuccessResponse<T>;
-      return { data: successResponse.data, totalCount: successResponse.totalCount, error: null };
-    } else {
-      return { data: handleNotFoundHttpError(response.error), error: null };
-    }
+    return `${this.environmentService.apiUrl}/api/` + url.replace(/^\/+|\/+$/g, "");
   }
 }

--- a/apps/web/src/app/shared/api/api.service.ts
+++ b/apps/web/src/app/shared/api/api.service.ts
@@ -69,10 +69,11 @@ export class ApiService {
     }
 
     const successResponse = await response.json() as ApiInternalSuccessResponse<T>;
-    return { data: successResponse.data, totalCount: successResponse.totalCount, error: null };
+    return { data: successResponse.data ?? null, totalCount: successResponse.totalCount, error: null };
   }
 
   private formatApiUrl(url: string): string {
-    return `${this.environmentService.apiUrl}/api/` + url.replace(/^\/+|\/+$/g, "");
+    const baseUrl = this.environmentService.apiUrl.replace(/\/+$/, '');
+    return `${baseUrl}/api/` + url.replace(/^\/+|\/+$/g, '');
   }
 }

--- a/apps/web/src/app/shared/db/supabase.service.ts
+++ b/apps/web/src/app/shared/db/supabase.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, inject } from '@angular/core';
-import { createClient, FunctionsHttpError, SupabaseClient } from '@supabase/supabase-js';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { Database } from './database.types';
 import { EnvironmentService } from '../services/environment.service';
 
@@ -22,11 +22,4 @@ export class SupabaseService {
     }
     return this._client;
   }
-}
-
-export function handleNotFoundHttpError(error: Error): null {
-  if (error instanceof FunctionsHttpError && error.context.status === 404) {
-    return null;
-  }
-  throw error;
 }

--- a/apps/web/src/app/shared/services/environment.service.ts
+++ b/apps/web/src/app/shared/services/environment.service.ts
@@ -16,6 +16,10 @@ export class EnvironmentService {
     return this.env.production;
   }
 
+  get apiUrl(): string {
+    return this.env.api.url;
+  }
+
   get supabaseUrl(): string {
     return this.env.supabase.url;
   }

--- a/apps/web/src/environments/environment.ts
+++ b/apps/web/src/environments/environment.ts
@@ -6,6 +6,9 @@ export const environment = {
     sha: '__BUILD_SHA__',
     tag: '__BUILD_TAG__',
   },
+  api: {
+    url: '__API_URL__',
+  },
   supabase: {
     url: '__SUPABASE_URL__',
     key: '__SUPABASE_ANON_KEY__',


### PR DESCRIPTION
## Summary

Phase 6 of the Azure migration (#28, #30): the Angular app now calls the Azure Functions API instead of Supabase Edge Functions. Supabase Auth and Postgres usage are unchanged; only the compute layer the frontend talks to moves.

- **`ApiService` rewritten** from `supabase.functions.invoke` to plain `fetch` against `${api.url}/api/...`, preserving the `Observable<ApiServiceResponse<T>>` contract so no callers change:
  - `Authorization: Bearer <access_token>` from `auth.getSession()` when a session exists (getSession refreshes expired tokens)
  - `Content-Type: application/json` on bodied methods
  - `404` **and** `204` resolve to `{ data: null, error: null }` — delete handlers return empty `204` bodies that must not be JSON-parsed
  - other non-2xx throw the `{ error }` envelope message
  - no `credentials` option: the API authenticates via the Authorization header and platform CORS runs without credential support
- **Environment config**: new `api.url` entry (`__API_URL__` substituted in CI from the `API_URL` GitHub environment variable, already set on both environments), exposed via `EnvironmentService`
- **Cleanup**: `FunctionsHttpError` handling (`handleNotFoundHttpError`) removed from `SupabaseService` — `ApiService` was its only consumer
- **Tests**: new `api.service.spec.ts` covering auth header, no-session, bodied requests, 204/404 handling, error envelopes, and network errors

## Verification

- Unit: 8/8 passing in `api.service.spec.ts`
- E2E against the local trio (Supabase + func host on :7071 + ng serve on :4200): **all specs passed** — 34 passing, 1 pending (35 total) across auth, plans, sessions, history
- Live staging API verified in #30 (health, auth envelope, CORS preflight via platform, warm latency ~130ms)

The staging CD run for this PR performs the real cutover validation: full E2E against the deployed frontend talking to `func-10xgains-staging`.

## Notes

- The old edge-function CD job stays until Phase 7 (cleanup), so both backends remain deployed during the transition.
- AUTH-07 (password reset flow) failed intermittently in local runs due to a pre-existing race in the test (the settings email input is aliased while the profile is still loading — `initialLoadFinished` renders the card immediately). It passed in the final run and is unrelated to this change; worth a flake-hardening follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)