### PR TITLE
ci: Skip Cypress binary outside E2E and fix workflow warnings

### DIFF
--- a/.github/workflows/on-pull-request-merge.yml
+++ b/.github/workflows/on-pull-request-merge.yml
@@ -13,6 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     steps:
+      - name: Suppress git default-branch hint
+        # actions/checkout runs `git init`, which prints the init.defaultBranch hint otherwise.
+        run: |
+          git config --global init.defaultBranch main
+
       - name: Checkout repository
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/on-pull-request-merge.yml
+++ b/.github/workflows/on-pull-request-merge.yml
@@ -13,8 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     steps:
-      - name: Suppress git default-branch hint
-        # actions/checkout runs `git init`, which prints the init.defaultBranch hint otherwise.
+      - name: Set git default branch
         run: |
           git config --global init.defaultBranch main
 

--- a/.github/workflows/reusable-cd.yml
+++ b/.github/workflows/reusable-cd.yml
@@ -46,8 +46,7 @@ jobs:
           echo "Error: e2e_scope must be either 'full' or 'smoke'"
           exit 1
 
-      - name: Suppress git default-branch hint
-        # actions/checkout runs `git init`, which prints the init.defaultBranch hint otherwise.
+      - name: Set git default branch
         run: |
           git config --global init.defaultBranch main
 
@@ -93,9 +92,6 @@ jobs:
 
       - name: Deploy to Azure Functions
         uses: Azure/functions-action@v1
-        env:
-          # The action's bundled dependencies emit a DEP0005 Buffer() deprecation warning.
-          NODE_OPTIONS: '--no-deprecation'
         with:
           app-name: ${{ vars.AZURE_FUNCTIONAPP_NAME }}
           package: apps/api/deploy
@@ -111,8 +107,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: Suppress git default-branch hint
-        # actions/checkout runs `git init`, which prints the init.defaultBranch hint otherwise.
+      - name: Set git default branch
         run: |
           git config --global init.defaultBranch main
 
@@ -125,8 +120,6 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Install Azure SWA CLI
-        # The SWA CLI pulls deprecated transitive dependencies we cannot fix here;
-        # raise the log level so npm does not warn about them on every deploy.
         run: |
           npm install -g @azure/static-web-apps-cli --loglevel error
 
@@ -162,9 +155,6 @@ jobs:
         # environments on pull_request events, ignoring deployment_environment. Staging deploys
         # run from PR-triggered pipelines and must target the SWA production environment, so we
         # deploy directly to the resource via the SWA CLI instead.
-        env:
-          # The SWA CLI's dependencies emit a DEP0005 Buffer() deprecation warning.
-          NODE_OPTIONS: '--no-deprecation'
         run: |
           swa deploy ./apps/web/dist/browser \
             --app-name ${{ vars.AZURE_STATIC_WEB_APP_NAME }} \
@@ -178,8 +168,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     steps:
-      - name: Suppress git default-branch hint
-        # actions/checkout runs `git init`, which prints the init.defaultBranch hint otherwise.
+      - name: Set git default branch
         run: |
           git config --global init.defaultBranch main
 
@@ -189,8 +178,6 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
         with:
-          # The standalone binary skips the pnpm self-installer, which warns about the
-          # pnpm v10 installation layout preinstalled at PNPM_HOME on the runner image.
           standalone: true
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-cd.yml
+++ b/.github/workflows/reusable-cd.yml
@@ -46,6 +46,11 @@ jobs:
           echo "Error: e2e_scope must be either 'full' or 'smoke'"
           exit 1
 
+      - name: Suppress git default-branch hint
+        # actions/checkout runs `git init`, which prints the init.defaultBranch hint otherwise.
+        run: |
+          git config --global init.defaultBranch main
+
       - name: Checkout repository
         uses: actions/checkout@v7
 
@@ -88,6 +93,9 @@ jobs:
 
       - name: Deploy to Azure Functions
         uses: Azure/functions-action@v1
+        env:
+          # The action's bundled dependencies emit a DEP0005 Buffer() deprecation warning.
+          NODE_OPTIONS: '--no-deprecation'
         with:
           app-name: ${{ vars.AZURE_FUNCTIONAPP_NAME }}
           package: apps/api/deploy
@@ -103,6 +111,11 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: Suppress git default-branch hint
+        # actions/checkout runs `git init`, which prints the init.defaultBranch hint otherwise.
+        run: |
+          git config --global init.defaultBranch main
+
       - name: Checkout repository
         uses: actions/checkout@v7
 
@@ -112,8 +125,10 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Install Azure SWA CLI
+        # The SWA CLI pulls deprecated transitive dependencies we cannot fix here;
+        # raise the log level so npm does not warn about them on every deploy.
         run: |
-          npm install -g @azure/static-web-apps-cli
+          npm install -g @azure/static-web-apps-cli --loglevel error
 
       - name: Download web app artifact
         uses: actions/download-artifact@v8
@@ -147,6 +162,9 @@ jobs:
         # environments on pull_request events, ignoring deployment_environment. Staging deploys
         # run from PR-triggered pipelines and must target the SWA production environment, so we
         # deploy directly to the resource via the SWA CLI instead.
+        env:
+          # The SWA CLI's dependencies emit a DEP0005 Buffer() deprecation warning.
+          NODE_OPTIONS: '--no-deprecation'
         run: |
           swa deploy ./apps/web/dist/browser \
             --app-name ${{ vars.AZURE_STATIC_WEB_APP_NAME }} \
@@ -160,11 +178,20 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     steps:
+      - name: Suppress git default-branch hint
+        # actions/checkout runs `git init`, which prints the init.defaultBranch hint otherwise.
+        run: |
+          git config --global init.defaultBranch main
+
       - name: Checkout repository
         uses: actions/checkout@v7
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
+        with:
+          # The standalone binary skips the pnpm self-installer, which warns about the
+          # pnpm v10 installation layout preinstalled at PNPM_HOME on the runner image.
+          standalone: true
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -37,6 +37,9 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
+        # Only the E2E job in the CD workflow runs Cypress; skip its binary download here.
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
         run: |
           pnpm install --frozen-lockfile
 
@@ -62,6 +65,9 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
+        # Only the E2E job in the CD workflow runs Cypress; skip its binary download here.
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
         run: |
           pnpm install --frozen-lockfile
 
@@ -97,6 +103,9 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
+        # Only the E2E job in the CD workflow runs Cypress; skip its binary download here.
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
         run: |
           pnpm install --frozen-lockfile
 
@@ -143,6 +152,9 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
+        # Only the E2E job in the CD workflow runs Cypress; skip its binary download here.
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
         run: |
           pnpm install --frozen-lockfile
 

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -24,11 +24,20 @@ jobs:
           echo "Error: environment must be either 'staging' or 'production'"
           exit 1
 
+      - name: Suppress git default-branch hint
+        # actions/checkout runs `git init`, which prints the init.defaultBranch hint otherwise.
+        run: |
+          git config --global init.defaultBranch main
+
       - name: Checkout repository
         uses: actions/checkout@v7
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
+        with:
+          # The standalone binary skips the pnpm self-installer, which warns about the
+          # pnpm v10 installation layout preinstalled at PNPM_HOME on the runner image.
+          standalone: true
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -52,11 +61,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint]
     steps:
+      - name: Suppress git default-branch hint
+        # actions/checkout runs `git init`, which prints the init.defaultBranch hint otherwise.
+        run: |
+          git config --global init.defaultBranch main
+
       - name: Checkout repository
         uses: actions/checkout@v7
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
+        with:
+          # The standalone binary skips the pnpm self-installer, which warns about the
+          # pnpm v10 installation layout preinstalled at PNPM_HOME on the runner image.
+          standalone: true
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -90,11 +108,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, test]
     steps:
+      - name: Suppress git default-branch hint
+        # actions/checkout runs `git init`, which prints the init.defaultBranch hint otherwise.
+        run: |
+          git config --global init.defaultBranch main
+
       - name: Checkout repository
         uses: actions/checkout@v7
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
+        with:
+          # The standalone binary skips the pnpm self-installer, which warns about the
+          # pnpm v10 installation layout preinstalled at PNPM_HOME on the runner image.
+          standalone: true
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -139,11 +166,20 @@ jobs:
     environment: ${{ inputs.environment }}
     needs: [lint, test]
     steps:
+      - name: Suppress git default-branch hint
+        # actions/checkout runs `git init`, which prints the init.defaultBranch hint otherwise.
+        run: |
+          git config --global init.defaultBranch main
+
       - name: Checkout repository
         uses: actions/checkout@v7
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
+        with:
+          # The standalone binary skips the pnpm self-installer, which warns about the
+          # pnpm v10 installation layout preinstalled at PNPM_HOME on the runner image.
+          standalone: true
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -24,8 +24,7 @@ jobs:
           echo "Error: environment must be either 'staging' or 'production'"
           exit 1
 
-      - name: Suppress git default-branch hint
-        # actions/checkout runs `git init`, which prints the init.defaultBranch hint otherwise.
+      - name: Set git default branch
         run: |
           git config --global init.defaultBranch main
 
@@ -35,8 +34,6 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
         with:
-          # The standalone binary skips the pnpm self-installer, which warns about the
-          # pnpm v10 installation layout preinstalled at PNPM_HOME on the runner image.
           standalone: true
 
       - name: Set up Node.js
@@ -46,7 +43,6 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        # Only the E2E job in the CD workflow runs Cypress; skip its binary download here.
         env:
           CYPRESS_INSTALL_BINARY: '0'
         run: |
@@ -61,8 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint]
     steps:
-      - name: Suppress git default-branch hint
-        # actions/checkout runs `git init`, which prints the init.defaultBranch hint otherwise.
+      - name: Set git default branch
         run: |
           git config --global init.defaultBranch main
 
@@ -72,8 +67,6 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
         with:
-          # The standalone binary skips the pnpm self-installer, which warns about the
-          # pnpm v10 installation layout preinstalled at PNPM_HOME on the runner image.
           standalone: true
 
       - name: Set up Node.js
@@ -83,7 +76,6 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        # Only the E2E job in the CD workflow runs Cypress; skip its binary download here.
         env:
           CYPRESS_INSTALL_BINARY: '0'
         run: |
@@ -108,8 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, test]
     steps:
-      - name: Suppress git default-branch hint
-        # actions/checkout runs `git init`, which prints the init.defaultBranch hint otherwise.
+      - name: Set git default branch
         run: |
           git config --global init.defaultBranch main
 
@@ -119,8 +110,6 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
         with:
-          # The standalone binary skips the pnpm self-installer, which warns about the
-          # pnpm v10 installation layout preinstalled at PNPM_HOME on the runner image.
           standalone: true
 
       - name: Set up Node.js
@@ -130,7 +119,6 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        # Only the E2E job in the CD workflow runs Cypress; skip its binary download here.
         env:
           CYPRESS_INSTALL_BINARY: '0'
         run: |
@@ -166,8 +154,7 @@ jobs:
     environment: ${{ inputs.environment }}
     needs: [lint, test]
     steps:
-      - name: Suppress git default-branch hint
-        # actions/checkout runs `git init`, which prints the init.defaultBranch hint otherwise.
+      - name: Set git default branch
         run: |
           git config --global init.defaultBranch main
 
@@ -177,8 +164,6 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
         with:
-          # The standalone binary skips the pnpm self-installer, which warns about the
-          # pnpm v10 installation layout preinstalled at PNPM_HOME on the runner image.
           standalone: true
 
       - name: Set up Node.js
@@ -188,7 +173,6 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        # Only the E2E job in the CD workflow runs Cypress; skip its binary download here.
         env:
           CYPRESS_INSTALL_BINARY: '0'
         run: |

--- a/apps/web/angular.json
+++ b/apps/web/angular.json
@@ -41,7 +41,7 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kB",
+                  "maximumWarning": "650kB",
                   "maximumError": "1MB"
                 },
                 {
@@ -63,7 +63,7 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kB",
+                  "maximumWarning": "650kB",
                   "maximumError": "1MB"
                 },
                 {

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -19,6 +19,7 @@ export default tseslint.config(
         typescript: {
           alwaysTryTypes: true,
           project: ['./tsconfig.json', './tsconfig.app.json', './tsconfig.spec.json'],
+          noWarnOnMultipleProjects: true,
         },
       },
     },

--- a/apps/web/tsconfig.spec.json
+++ b/apps/web/tsconfig.spec.json
@@ -13,8 +13,7 @@
     }
   },
   "include": [
-    "src/**/*.spec.ts",
-    "src/**/*.d.ts"
+    "src/**/*.ts"
   ],
   "files": [
     "src/test-setup.ts"

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -6,9 +6,15 @@ import { tasks } from "./cypress/support/tasks";
 config();
 
 export default defineConfig({
+  // Secrets stay in `env` and are read in specs via the cy.env() command;
+  // Cypress.env() in the browser is deprecated, so opt out of it entirely.
+  allowCypressEnv: false,
   env: {
     CANARY_USER_EMAIL: process.env['APP_CANARY_USER_EMAIL'],
     CANARY_USER_PASSWORD: process.env['APP_CANARY_USER_PASSWORD'],
+  },
+  // Non-secret values exposed to the browser, read via Cypress.expose().
+  expose: {
     ENVIRONMENT: process.env['CYPRESS_ENVIRONMENT'],
   },
   e2e: {

--- a/cypress/e2e/auth/auth.cy.ts
+++ b/cypress/e2e/auth/auth.cy.ts
@@ -70,7 +70,11 @@ describe('Authentication', { tags: ['@auth'] }, () => {
       cy.intercept('POST', '/auth/v1/recover*').as('recover');
 
       cy.getBySel(dataCy.auth.login.resetPasswordButton).click();
-      cy.env<{ CANARY_USER_EMAIL: string }>(['CANARY_USER_EMAIL']).then(({ CANARY_USER_EMAIL }) => {
+      cy.env<{ CANARY_USER_EMAIL?: string }>(['CANARY_USER_EMAIL']).then(({ CANARY_USER_EMAIL }) => {
+        if (!CANARY_USER_EMAIL) {
+          throw new Error('Canary user email not found in environment variables');
+        }
+
         cy.getBySel(dataCy.auth.resetPassword.emailInput).type(CANARY_USER_EMAIL);
       });
       cy.getBySel(dataCy.auth.resetPassword.requestSignInLinkButton).click();

--- a/cypress/e2e/auth/auth.cy.ts
+++ b/cypress/e2e/auth/auth.cy.ts
@@ -67,11 +67,12 @@ describe('Authentication', { tags: ['@auth'] }, () => {
     });
 
     it('allows a user to request a password reset', { tags: ['AUTH-06'] }, () => {
-      const email = Cypress.env('CANARY_USER_EMAIL');
       cy.intercept('POST', '/auth/v1/recover*').as('recover');
 
       cy.getBySel(dataCy.auth.login.resetPasswordButton).click();
-      cy.getBySel(dataCy.auth.resetPassword.emailInput).type(email);
+      cy.env<{ CANARY_USER_EMAIL: string }>(['CANARY_USER_EMAIL']).then(({ CANARY_USER_EMAIL }) => {
+        cy.getBySel(dataCy.auth.resetPassword.emailInput).type(CANARY_USER_EMAIL);
+      });
       cy.getBySel(dataCy.auth.resetPassword.requestSignInLinkButton).click();
 
       cy.wait('@recover').then(() => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -62,7 +62,7 @@ export {};
  * Helper functions for commands
  */
 const isSmoke = () => Cypress.currentTestTags?.includes('@smoke') ?? false;
-const isStaging = () => Cypress.env('ENVIRONMENT') === 'development' || Cypress.env('ENVIRONMENT') === 'staging';
+const isStaging = () => Cypress.expose('ENVIRONMENT') === 'development' || Cypress.expose('ENVIRONMENT') === 'staging';
 
 const getProcessedTestTags = () => {
   const tags = Cypress.currentTestTags ?? [];
@@ -73,14 +73,17 @@ const getProcessedTestTags = () => {
 };
 
 function loginAsCanaryUser(): void {
-  const email = Cypress.env('CANARY_USER_EMAIL').trim();
-  const password = Cypress.env('CANARY_USER_PASSWORD').trim();
+  cy.env<{ CANARY_USER_EMAIL?: string; CANARY_USER_PASSWORD?: string }>(['CANARY_USER_EMAIL', 'CANARY_USER_PASSWORD'])
+    .then(({ CANARY_USER_EMAIL, CANARY_USER_PASSWORD }) => {
+      const email = CANARY_USER_EMAIL?.trim();
+      const password = CANARY_USER_PASSWORD?.trim();
 
-  if (!email || !password) {
-    throw new Error('Canary user credentials not found in environment variables');
-  }
+      if (!email || !password) {
+        throw new Error('Canary user credentials not found in environment variables');
+      }
 
-  fillLoginForm(email, password);
+      fillLoginForm(email, password);
+    });
 }
 
 function loginAsEphemeralUser(): void {


### PR DESCRIPTION
## Summary

Two goals, based on warnings observed in [run 28736309635](https://github.com/dmngrsk/10xGains/actions/runs/28736309635):

### Skip the Cypress binary download in non-E2E jobs

Cypress is a root workspace dependency with a trusted postinstall script, so every `pnpm install` in CI (lint, test, build-api, build-web) downloaded the Cypress binary even though only the CD E2E job runs Cypress. Those jobs now set `CYPRESS_INSTALL_BINARY=0`; the E2E job still installs the binary as before.

### Fix the warnings in the run logs

| Warning | Fix |
|---|---|
| ~60× Analog Vite plugin "contains Angular decorators but is not in the TypeScript program" (unit tests) | `tsconfig.spec.json` now includes all `src/**/*.ts`, so decorated files imported by specs are part of the test TS program |
| eslint "Multiple projects found, consider using a single tsconfig" (lint) | `noWarnOnMultipleProjects: true` in the import resolver settings — the three projects are intentional |
| Angular "bundle initial exceeded maximum budget" 609.3 kB > 500 kB (web build) | Raised `maximumWarning` to 650 kB (error threshold stays 1 MB). This is a threshold change, not a size reduction — say the word if you'd rather budget-hunt the bundle instead |
| Cypress "allowCypressEnv configuration option is enabled ... insecure and will be removed" (E2E) | Migrated to Cypress 15's new APIs: `allowCypressEnv: false`, canary credentials read via `cy.env()`, non-secret `ENVIRONMENT` moved to `expose` and read via `Cypress.expose()` (matching what `@cypress/grep` v6 and the existing `--expose` flag in `e2e:smoke` already use) |
| git "hint: Using 'master' as the name for the initial branch" (every checkout) | Set `init.defaultBranch main` in a step before each checkout |
| pnpm "[WARN] Detected a pnpm v10 installation layout at PNPM_HOME" (every pnpm setup) | `standalone: true` on `pnpm/action-setup`, which skips the pnpm self-installer that trips over the runner image's preinstalled v10 layout |
| npm deprecation warnings installing the Azure SWA CLI (frontend deploy) | `--loglevel error` on the global install — the deprecated packages are upstream transitive dependencies we can't fix |

Left as-is: the `DEP0005` Buffer() deprecation in the Azure Functions/SWA deploy steps comes from the Azure tooling's bundled dependencies — suppressing it would only hide the upstream issue. `if-no-files-found: warn` and `tar --warning=no-unknown-keyword` lines in the logs are configuration echoes, not actual warnings.

## Verification

- `pnpm lint` passes with no warnings (multiple-projects warning gone)
- `pnpm --filter @txg/web test`: 218 tests pass with zero Analog warnings (previously ~60)
- `pnpm build:staging` builds clean: initial total 609.19 kB, under the new 650 kB threshold
- Edited workflow YAML parses cleanly; the pnpm `standalone` and git-hint fixes are best verified by this PR's own CI run
- E2E changes will be exercised by the staging E2E suite in this PR's CD stage (requires the usual deploy approval)

🤖 Generated with [Claude Code](https://claude.com/claude-code)