### PR TITLE
test(e2e): Add reorder test for plan days, exercises and sets

### DIFF
--- a/apps/web/src/app/features/plans/pages/plan-edit-page/components/plan-day-item/plan-day-item.component.html
+++ b/apps/web/src/app/features/plans/pages/plan-edit-page/components/plan-day-item/plan-day-item.component.html
@@ -9,7 +9,7 @@
   <mat-expansion-panel-header>
     <div class="flex items-center w-full">
       @if (!isReadOnly) {
-        <div cdkDragHandle class="flex items-center cursor-grab pr-2 text-outline">
+        <div cdkDragHandle class="flex items-center cursor-grab pr-2 text-outline" data-cy="plan-edit-day-drag-handle">
           <mat-icon>drag_indicator</mat-icon>
         </div>
       }

--- a/apps/web/src/app/features/plans/pages/plan-edit-page/components/plan-exercise-item/plan-exercise-item.component.html
+++ b/apps/web/src/app/features/plans/pages/plan-edit-page/components/plan-exercise-item/plan-exercise-item.component.html
@@ -9,7 +9,7 @@
   <mat-expansion-panel-header>
     <div class="flex items-center w-full">
       @if (!isReadOnly) {
-        <div cdkDragHandle class="flex items-center cursor-grab pr-2 text-outline">
+        <div cdkDragHandle class="flex items-center cursor-grab pr-2 text-outline" data-cy="plan-exercise-drag-handle">
           <mat-icon>drag_indicator</mat-icon>
         </div>
       }

--- a/apps/web/src/app/features/plans/pages/plan-edit-page/components/plan-exercise-set-item/plan-exercise-set-item.component.html
+++ b/apps/web/src/app/features/plans/pages/plan-edit-page/components/plan-exercise-set-item/plan-exercise-set-item.component.html
@@ -2,7 +2,7 @@
   <mat-card-content>
     <div class="flex min-h-12 items-center justify-between">
       @if (!isReadOnly) {
-        <div cdkDragHandle class="flex items-center cursor-grab pr-2 text-outline">
+        <div cdkDragHandle class="flex items-center cursor-grab pr-2 text-outline" data-cy="plan-exercise-set-drag-handle">
           <button mat-icon-button>
             <mat-icon>drag_indicator</mat-icon>
             </button>

--- a/cypress/e2e/plans/plans.cy.ts
+++ b/cypress/e2e/plans/plans.cy.ts
@@ -125,15 +125,59 @@ describe('Plan Management', { tags: ['@plans'] }, () => {
       });
     });
 
-    it.skip('TODO: allows a user to reorder training days, exercises and sets', { tags: ['@todo', 'PLAN-07'] }, () => {
-      // Reorder days
-      // ...
+    it('allows a user to reorder training days, exercises and sets', { tags: ['PLAN-07'] }, () => {
+      // Reorder days: Workout A and Workout B swap places
+      cy.getBySel(dataCy.plans.planEdit.days.name).eq(0).should('contain.text', 'Workout A');
+      cy.getBySel(dataCy.plans.planEdit.days.name).eq(1).should('contain.text', 'Workout B');
 
-      // Reorder exercises
-      // ...
+      cy.dragBySel(dataCy.plans.planEdit.days.dragHandle, dataCy.plans.planEdit.days.item, 0, 1);
 
-      // Reorder sets
-      // ...
+      cy.getBySel(dataCy.plans.planEdit.days.name).eq(0).should('contain.text', 'Workout B');
+      cy.getBySel(dataCy.plans.planEdit.days.name).eq(1).should('contain.text', 'Workout A');
+      cy.getMatSnackBar().should('contain.text', 'Day order updated');
+
+      // Reorder exercises: within Workout A (now the second day), Squat and Bench Press swap places.
+      // Scoped with .within(), since a collapsed day/exercise panel's content stays mounted in the
+      // DOM (just hidden), so unscoped selectors would also match the other day's exercises/sets.
+      cy.getBySel(dataCy.plans.planEdit.days.item).eq(1).click();
+      cy.getBySel(dataCy.plans.planEdit.days.item).eq(1).within(() => {
+        cy.getBySel(dataCy.plans.planEdit.exercises.name).eq(0).should('contain.text', 'Squat');
+        cy.getBySel(dataCy.plans.planEdit.exercises.name).eq(1).should('contain.text', 'Bench Press');
+
+        cy.dragBySel(dataCy.plans.planEdit.exercises.dragHandle, dataCy.plans.planEdit.exercises.item, 0, 1);
+
+        cy.getBySel(dataCy.plans.planEdit.exercises.name).eq(0).should('contain.text', 'Bench Press');
+        cy.getBySel(dataCy.plans.planEdit.exercises.name).eq(1).should('contain.text', 'Squat');
+      });
+      cy.getMatSnackBar().should('contain.text', 'Exercise order updated');
+
+      // Reorder sets: within Bench Press (now the first exercise of Workout A), give the second set
+      // a distinct value so reordering can be observed, then move it to the first position
+      cy.getBySel(dataCy.plans.planEdit.days.item).eq(1).within(() => {
+        cy.getBySel(dataCy.plans.planEdit.exercises.item).eq(0).click();
+        cy.getBySel(dataCy.plans.planEdit.exercises.item).eq(0).within(() => {
+          cy.getBySel(dataCy.plans.planEdit.sets.editButton).eq(1).click();
+        });
+      });
+      cy.getBySel(dataCy.plans.dialogs.sets.repsInput).clear().type('8');
+      cy.getBySel(dataCy.plans.dialogs.sets.weightInput).clear().type('75');
+      cy.getBySel(dataCy.plans.dialogs.sets.saveButton).click();
+      cy.getBySel(dataCy.plans.dialogs.sets.content).should('not.exist');
+
+      cy.getBySel(dataCy.plans.planEdit.days.item).eq(1).within(() => {
+        cy.getBySel(dataCy.plans.planEdit.exercises.item).eq(0).within(() => {
+          cy.getBySel(dataCy.plans.planEdit.sets.details).eq(0).should('contain.text', '5 x 70kg');
+          cy.getBySel(dataCy.plans.planEdit.sets.details).eq(1).should('contain.text', '8 x 75kg');
+          cy.getBySel(dataCy.plans.planEdit.sets.details).eq(2).should('contain.text', '5 x 70kg');
+
+          cy.dragBySel(dataCy.plans.planEdit.sets.dragHandle, dataCy.plans.planEdit.sets.item, 1, 0);
+
+          cy.getBySel(dataCy.plans.planEdit.sets.details).eq(0).should('contain.text', '8 x 75kg');
+          cy.getBySel(dataCy.plans.planEdit.sets.details).eq(1).should('contain.text', '5 x 70kg');
+          cy.getBySel(dataCy.plans.planEdit.sets.details).eq(2).should('contain.text', '5 x 70kg');
+        });
+      });
+      cy.getMatSnackBar().should('contain.text', 'Set order updated');
     });
 
     it('allows a user to activate a plan', { tags: ['PLAN-08'] }, () => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -57,8 +57,11 @@ function dragBySel(handleSelector: string, itemSelector: string, fromIndex: numb
 
       cy.wrap($handle).trigger('mousedown', { eventConstructor: 'MouseEvent', button: 0, buttons: 1, detail: 1, clientX: startX, clientY: startY, force: true });
 
+      // CDK moves the dragged element (and its handle) to a hidden overlay under <body> once
+      // dragging starts, so subsequent events are dispatched on the document instead of the
+      // handle - that's also where CDK's own move/up listeners are bound.
       for (let step = 1; step <= steps; step++) {
-        cy.wrap($handle).trigger('mousemove', {
+        cy.document().trigger('mousemove', {
           eventConstructor: 'MouseEvent',
           button: 0,
           buttons: 1,
@@ -68,7 +71,7 @@ function dragBySel(handleSelector: string, itemSelector: string, fromIndex: numb
         });
       }
 
-      cy.wrap($handle).trigger('mouseup', { eventConstructor: 'MouseEvent', clientX: targetX, clientY: targetY, force: true });
+      cy.document().trigger('mouseup', { eventConstructor: 'MouseEvent', clientX: targetX, clientY: targetY, force: true });
     });
   });
 }

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -5,6 +5,7 @@ Cypress.Commands.add('teardown', teardown);
 Cypress.Commands.add('navigateTo', navigateTo);
 Cypress.Commands.add('navigateBack', navigateBack);
 Cypress.Commands.add('getBySel', getBySel);
+Cypress.Commands.add('dragBySel', dragBySel);
 Cypress.Commands.add('getMatSnackBar', getMatSnackBar);
 Cypress.Commands.add('longPress', { prevSubject: 'element' }, (s, d) => longPress(s, d as unknown as number));
 
@@ -44,6 +45,32 @@ function navigateBack(): void {
 
 function getBySel(selector: string, options?: Partial<Cypress.Loggable & Cypress.Timeoutable & Cypress.Withinable & Cypress.Shadow>): Cypress.Chainable<JQuery<HTMLElement>> {
   return cy.get(`[data-cy=${selector}]`, options);
+}
+
+function dragBySel(handleSelector: string, itemSelector: string, fromIndex: number, toIndex: number): void {
+  getBySel(itemSelector).eq(toIndex).then(($target) => {
+    const { x: targetX, y: targetY } = elementCenter($target[0]);
+
+    getBySel(handleSelector).eq(fromIndex).then(($handle) => {
+      const { x: startX, y: startY } = elementCenter($handle[0]);
+      const steps = 5;
+
+      cy.wrap($handle).trigger('mousedown', { eventConstructor: 'MouseEvent', button: 0, buttons: 1, detail: 1, clientX: startX, clientY: startY, force: true });
+
+      for (let step = 1; step <= steps; step++) {
+        cy.wrap($handle).trigger('mousemove', {
+          eventConstructor: 'MouseEvent',
+          button: 0,
+          buttons: 1,
+          clientX: startX + ((targetX - startX) * step) / steps,
+          clientY: startY + ((targetY - startY) * step) / steps,
+          force: true,
+        });
+      }
+
+      cy.wrap($handle).trigger('mouseup', { eventConstructor: 'MouseEvent', clientX: targetX, clientY: targetY, force: true });
+    });
+  });
 }
 
 function getMatSnackBar(): Cypress.Chainable<JQuery<HTMLElement>> {
@@ -108,4 +135,9 @@ function fillLoginForm(email: string, password: string): void {
 
   cy.url().should('include', '/home');
   cy.getBySel(dataCy.home.sessionCard).should('exist');
+}
+
+function elementCenter(element: HTMLElement): { x: number; y: number } {
+  const rect = element.getBoundingClientRect();
+  return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
 }

--- a/cypress/support/cypress.d.ts
+++ b/cypress/support/cypress.d.ts
@@ -35,6 +35,16 @@ namespace Cypress {
     getBySel(selector: string, options?: Partial<Cypress.Loggable & Cypress.Timeoutable & Cypress.Withinable & Cypress.Shadow>): Cypress.Chainable<JQuery<HTMLElement>>;
 
     /**
+     * Simulate an Angular CDK drag-and-drop gesture (mousedown/mousemove/mouseup),
+     * dragging an item's handle from one position in a list to another item's position.
+     * @param handleSelector The data-cy attribute value of the cdkDragHandle element.
+     * @param itemSelector The data-cy attribute value of the draggable item, used to compute the drop position.
+     * @param fromIndex The index (among matched handle elements) of the item to drag.
+     * @param toIndex The index (among matched item elements) of the item to drop onto.
+     */
+    dragBySel(handleSelector: string, itemSelector: string, fromIndex: number, toIndex: number): void;
+
+    /**
      * Get the Material Snackbar element.
      * @returns A chainable object that can be used to interact with the element.
      */

--- a/cypress/support/selectors/plans/plan-edit.selectors.ts
+++ b/cypress/support/selectors/plans/plan-edit.selectors.ts
@@ -11,6 +11,7 @@ export const planEditSelectors = {
     name: 'plan-edit-day-name',
     editButton: 'plan-edit-day-edit-button',
     addExerciseButton: 'plan-day-add-exercise-button',
+    dragHandle: 'plan-edit-day-drag-handle',
   },
   exercises: {
     item: 'plan-exercise-item',
@@ -19,11 +20,13 @@ export const planEditSelectors = {
     addProgressionButton: 'plan-exercise-add-progression-button',
     editProgressionButton: 'plan-exercise-edit-progression-button',
     addSetButton: 'plan-exercise-add-set-button',
+    dragHandle: 'plan-exercise-drag-handle',
   },
   sets: {
     item: 'plan-exercise-set-item',
     details: 'plan-exercise-set-details',
     editButton: 'plan-exercise-set-edit-button',
     deleteButton: 'plan-exercise-set-delete-button',
+    dragHandle: 'plan-exercise-set-drag-handle',
   },
 };


### PR DESCRIPTION
## Summary
- Closes #9. Implements the previously-skipped PLAN-07 e2e test, which drags plan days, exercises, and sets into new positions and verifies the reordered UI plus the confirmation snackbar for each level.
- Adds `data-cy` handles to the `cdkDragHandle` elements for days, exercises, and sets, since none existed to target in Cypress.
- Adds a `cy.dragBySel()` custom command that simulates Angular CDK's drag-and-drop gesture (mousedown/mousemove/mouseup with `eventConstructor: 'MouseEvent'`, `buttons`/`detail` set) — CDK treats synthetic events missing those fields as fake screen-reader input and ignores them.

## Test plan
- [x] `pnpm --filter @txg/e2e lint` and `pnpm --filter @txg/web lint` pass
- [x] `cypress run --spec cypress/e2e/plans/plans.cy.ts` — all 10 tests pass, including the new PLAN-07 test
- [x] Full `cypress run` (auth, history, plans, sessions) — 35/35 pass, no regressions