### PR TITLE
feat: Session rest alerts via Web Push

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -198,6 +198,7 @@ jobs:
             -e "s|__API_URL__|${{ vars.API_URL }}|g" \
             -e "s|__SUPABASE_URL__|${{ vars.SUPABASE_URL }}|g" \
             -e "s|__SUPABASE_PUBLISHABLE_KEY__|${{ secrets.SUPABASE_PUBLISHABLE_KEY }}|g" \
+            -e "s|__VAPID_PUBLIC_KEY__|${{ vars.VAPID_PUBLIC_KEY }}|g" \
             "$OUTPUT_FILE"
 
           echo "Generated ${OUTPUT_FILE}:"

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -20,6 +20,7 @@ This workspace package (`@txg/api`) contains the main API for the 10xGains appli
   - [Plan Exercise Progression API](#plan-exercise-progression-api)
   - [Sessions API](#sessions-api)
   - [Session Sets API](#session-sets-api)
+  - [Push API](#push-api)
   - [Health Check API](#health-check-api)
 
 ## Architecture
@@ -1487,6 +1488,44 @@ Marks a specific set as pending.
     -   `400 Bad Request`: If path parameter formats are invalid.
     -   `401 Unauthorized`: If the authentication token is invalid or missing.
     -   `404 Not Found`: If the training session or set is not found or not accessible.
+    -   `500 Internal Server Error`: If an unexpected server error occurs.
+
+### Push API
+
+The Push API manages a user's Web Push subscriptions. The backend uses these to
+deliver session rest/idle notifications via a background queue-triggered function
+(`sendPush`), scheduled when a set is completed/failed. All endpoints require
+authentication and operate only on the authenticated user's subscriptions.
+
+#### POST /api/push/subscriptions
+
+Registers (or refreshes) a Web Push subscription for the current user, keyed by
+its browser `endpoint`.
+
+-   **Authorization**: Bearer token required.
+-   **Request Body**: The browser `PushSubscription.toJSON()` shape.
+    ```json
+    {
+      "endpoint": "https://fcm.googleapis.com/fcm/send/abc123",
+      "keys": { "p256dh": "<base64>", "auth": "<base64>" }
+    }
+    ```
+-   **Response (201 Created)**: The stored subscription.
+-   **Responses (Error)**:
+    -   `400 Bad Request`: If the body is missing required fields.
+    -   `401 Unauthorized`: If the authentication token is invalid or missing.
+    -   `500 Internal Server Error`: If an unexpected server error occurs.
+
+#### DELETE /api/push/subscriptions
+
+Removes a subscription for the current user (e.g. on unsubscribe).
+
+-   **Authorization**: Bearer token required.
+-   **Query Parameters**: `endpoint` (required) — the push endpoint to remove.
+-   **Response (204 No Content)**: On success.
+-   **Responses (Error)**:
+    -   `400 Bad Request`: If `endpoint` is missing or malformed.
+    -   `401 Unauthorized`: If the authentication token is invalid or missing.
     -   `500 Internal Server Error`: If an unexpected server error occurs.
 
 ### Health Check API

--- a/apps/api/local.settings.json.example
+++ b/apps/api/local.settings.json.example
@@ -5,6 +5,10 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "APP_URL": "http://localhost:4200",
     "SUPABASE_URL": "http://127.0.0.1:54321",
-    "SUPABASE_PUBLISHABLE_KEY": "<local supabase publishable key from `supabase start`>"
+    "SUPABASE_PUBLISHABLE_KEY": "<local supabase publishable key from `supabase start`>",
+    "SUPABASE_SECRET_KEY": "<local supabase secret key from `supabase start`; used only by the push queue trigger>",
+    "VAPID_SUBJECT": "mailto:you@example.com",
+    "VAPID_PUBLIC_KEY": "<VAPID public key from `npx web-push generate-vapid-keys`>",
+    "VAPID_PRIVATE_KEY": "<VAPID private key from `npx web-push generate-vapid-keys`>"
   }
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,14 +18,17 @@
   },
   "dependencies": {
     "@azure/functions": "^4.7.0",
+    "@azure/storage-queue": "^12.31.0",
     "@marplex/hono-azurefunc-adapter": "^1.0.1",
     "@supabase/supabase-js": "^2.49.4",
     "@txg/shared": "workspace:*",
     "hono": "^4.7.0",
+    "web-push": "^3.6.7",
     "zod": "^3.24.3"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",
+    "@types/web-push": "^3.6.4",
     "@vitest/coverage-v8": "^3.2.2",
     "azure-functions-core-tools": "^4",
     "esbuild": "^0.25.0",

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -4,6 +4,7 @@ import type { PlanRepository } from './repositories/plan.repository';
 import type { ExerciseRepository } from './repositories/exercise.repository';
 import type { ProfileRepository } from './repositories/profile.repository';
 import type { SessionRepository } from './repositories/session.repository';
+import type { PushSubscriptionRepository } from './repositories/push-subscription.repository';
 
 /**
  * Placeholder for TelemetryClient - can be expanded later
@@ -31,5 +32,6 @@ export type AppContext = {
     exerciseRepository: ExerciseRepository;
     profileRepository: ProfileRepository;
     sessionRepository: SessionRepository;
+    pushSubscriptionRepository: PushSubscriptionRepository;
   };
 };

--- a/apps/api/src/functions/send-push.ts
+++ b/apps/api/src/functions/send-push.ts
@@ -1,0 +1,42 @@
+import { app, InvocationContext } from '@azure/functions';
+import { setVapidDetails } from 'web-push';
+import { createAdminSupabaseClient } from '../utils/supabase-admin';
+import { processSessionAlert } from '../services/push/push-sender';
+import { parseSessionAlertMessage } from '../services/push/session-alert-message';
+
+let vapidConfigured = false;
+
+function ensureVapidConfigured(): void {
+  if (vapidConfigured) {
+    return;
+  }
+  setVapidDetails(
+    process.env['VAPID_SUBJECT'] ?? '',
+    process.env['VAPID_PUBLIC_KEY'] ?? '',
+    process.env['VAPID_PRIVATE_KEY'] ?? ''
+  );
+  vapidConfigured = true;
+}
+
+export async function sendPush(queueItem: unknown, context: InvocationContext): Promise<void> {
+  const message = parseSessionAlertMessage(queueItem);
+  if (!message) {
+    context.warn('Received an invalid session alert message; skipping.');
+    return;
+  }
+
+  ensureVapidConfigured();
+  const supabase = createAdminSupabaseClient();
+
+  try {
+    await processSessionAlert(supabase, message);
+  } catch (e) {
+    context.error('Failed to process session alert', e);
+  }
+}
+
+app.storageQueue('sendPush', {
+  queueName: 'session-alerts',
+  connection: 'AzureWebJobsStorage',
+  handler: sendPush,
+});

--- a/apps/api/src/handlers/push/delete.ts
+++ b/apps/api/src/handlers/push/delete.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+import type { Context } from 'hono';
+import type { AppContext } from '../../context';
+import { handleRepositoryError } from '../../utils/api-helpers';
+import { validateQueryParams } from '../../utils/validation';
+
+const QUERY_SCHEMA = z.object({
+  endpoint: z.string().url('Invalid push endpoint URL'),
+});
+
+export async function handleDeletePushSubscription(c: Context<AppContext>) {
+  const { query, error: queryError } = validateQueryParams(c, QUERY_SCHEMA);
+  if (queryError) return queryError;
+
+  const pushSubscriptionRepository = c.get('pushSubscriptionRepository');
+
+  try {
+    await pushSubscriptionRepository.deleteByEndpoint(query!.endpoint);
+    return c.body(null, 204);
+  } catch (e) {
+    const fallbackMessage = 'Failed to delete push subscription';
+    return handleRepositoryError(c, e as Error, pushSubscriptionRepository.handlePushSubscriptionError, handleDeletePushSubscription.name, fallbackMessage);
+  }
+}

--- a/apps/api/src/handlers/push/post.ts
+++ b/apps/api/src/handlers/push/post.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+import type { Context } from 'hono';
+import type { PushSubscriptionDto, UpsertPushSubscriptionCommand } from '@txg/shared';
+import type { AppContext } from '../../context';
+import { createSuccessData, handleRepositoryError } from '../../utils/api-helpers';
+import { validateCommandBody } from '../../utils/validation';
+
+const COMMAND_SCHEMA = z.object({
+  endpoint: z.string().url('Invalid push endpoint URL'),
+  keys: z.object({
+    p256dh: z.string().min(1, 'Missing p256dh key'),
+    auth: z.string().min(1, 'Missing auth key'),
+  }),
+});
+
+export async function handleUpsertPushSubscription(c: Context<AppContext>) {
+  const { command, error: commandError } = await validateCommandBody<typeof COMMAND_SCHEMA, UpsertPushSubscriptionCommand>(c, COMMAND_SCHEMA);
+  if (commandError) return commandError;
+
+  const pushSubscriptionRepository = c.get('pushSubscriptionRepository');
+
+  try {
+    const subscription = await pushSubscriptionRepository.upsert(command!);
+
+    const successData = createSuccessData<PushSubscriptionDto>(subscription);
+    return c.json(successData, 201);
+  } catch (e) {
+    const fallbackMessage = 'Failed to save push subscription';
+    return handleRepositoryError(c, e as Error, pushSubscriptionRepository.handlePushSubscriptionError, handleUpsertPushSubscription.name, fallbackMessage);
+  }
+}

--- a/apps/api/src/handlers/session-sets/helpers/patch-base.ts
+++ b/apps/api/src/handlers/session-sets/helpers/patch-base.ts
@@ -7,7 +7,8 @@ export async function patch(
   c: Context<AppContext>,
   sessionId: string,
   setId: string,
-  getUpdateSetData: (set: SessionSetDto) => Partial<SessionSetDto>
+  getUpdateSetData: (set: SessionSetDto) => Partial<SessionSetDto>,
+  afterUpdate?: (updatedSet: SessionSetDto) => Promise<void>
 ): Promise<Response> {
   const sessionRepository = c.get('sessionRepository');
 
@@ -24,6 +25,11 @@ export async function patch(
     if (!updatedSet) {
       const errorData = createErrorDataWithLogging(404, 'Session set not found for update.');
       return c.json(errorData, 404);
+    }
+
+    // Best-effort side effect (e.g. scheduling push alerts); must not throw.
+    if (afterUpdate) {
+      await afterUpdate(updatedSet);
     }
 
     const successData = createSuccessData(updatedSet, { message: 'Session set updated successfully.' });

--- a/apps/api/src/handlers/session-sets/patch-complete.ts
+++ b/apps/api/src/handlers/session-sets/patch-complete.ts
@@ -4,6 +4,7 @@ import type { SessionSetDto } from '@txg/shared';
 import type { AppContext } from '../../context';
 import { patch } from './helpers/patch-base';
 import { validatePathParams } from "../../utils/validation";
+import { REST_OVER_COMPLETE_SECONDS, scheduleRestAlerts } from '../../services/push/session-alert-scheduler';
 
 const PATH_SCHEMA = z.object({
   sessionId: z.string().uuid('Invalid sessionId format'),
@@ -20,5 +21,7 @@ export async function handleCompleteSessionSet(c: Context<AppContext>) {
     completed_at: new Date().toISOString()
   });
 
-  return await patch(c, path!.sessionId, path!.setId, getUpdateData);
+  return await patch(c, path!.sessionId, path!.setId, getUpdateData, () =>
+    scheduleRestAlerts(c.get('user').id, path!.sessionId, path!.setId, REST_OVER_COMPLETE_SECONDS)
+  );
 }

--- a/apps/api/src/handlers/session-sets/patch-fail.ts
+++ b/apps/api/src/handlers/session-sets/patch-fail.ts
@@ -4,6 +4,7 @@ import type { SessionSetDto } from '@txg/shared';
 import type { AppContext } from '../../context';
 import { patch } from './helpers/patch-base';
 import { validatePathParams, validateQueryParams } from "../../utils/validation";
+import { REST_OVER_FAIL_SECONDS, scheduleRestAlerts } from '../../services/push/session-alert-scheduler';
 
 const PATH_SCHEMA = z.object({
   sessionId: z.string().uuid('Invalid sessionId format'),
@@ -30,5 +31,7 @@ export async function handleFailSessionSet(c: Context<AppContext>) {
     completed_at: new Date().toISOString()
   });
 
-  return await patch(c, path!.sessionId, path!.setId, getUpdateData);
+  return await patch(c, path!.sessionId, path!.setId, getUpdateData, () =>
+    scheduleRestAlerts(c.get('user').id, path!.sessionId, path!.setId, REST_OVER_FAIL_SECONDS)
+  );
 }

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,6 +1,8 @@
 import { app } from '@azure/functions';
 import { azureHonoHandler } from '@marplex/hono-azurefunc-adapter';
 import honoApp from './app';
+// Side-effect import: registers the `sendPush` storage-queue trigger.
+import './functions/send-push';
 
 // Single catch-all HTTP function: Azure Functions is only the transport,
 // all routing/middleware lives in the Hono app. Combined with host.json's

--- a/apps/api/src/middleware/repositories.ts
+++ b/apps/api/src/middleware/repositories.ts
@@ -4,6 +4,7 @@ import { PlanRepository } from '../repositories/plan.repository';
 import { ExerciseRepository } from '../repositories/exercise.repository';
 import { ProfileRepository } from '../repositories/profile.repository';
 import { SessionRepository } from '../repositories/session.repository';
+import { PushSubscriptionRepository } from '../repositories/push-subscription.repository';
 
 /**
  * Middleware to initialize and inject repositories into the Hono context.
@@ -28,6 +29,7 @@ export async function repositoriesMiddleware(c: Context<AppContext>, next: Next)
   c.set('exerciseRepository', new ExerciseRepository(supabase));
   c.set('profileRepository', new ProfileRepository(supabase, getUserId));
   c.set('sessionRepository', new SessionRepository(supabase, getUserId));
+  c.set('pushSubscriptionRepository', new PushSubscriptionRepository(supabase, getUserId));
 
   await next();
 }

--- a/apps/api/src/middleware/routes.ts
+++ b/apps/api/src/middleware/routes.ts
@@ -44,6 +44,8 @@ import { handleDeleteSessionSetById } from '../handlers/session-sets/delete-id';
 import { handleCompleteSessionSet } from '../handlers/session-sets/patch-complete';
 import { handleFailSessionSet } from '../handlers/session-sets/patch-fail';
 import { handleResetSessionSet } from '../handlers/session-sets/patch-reset';
+import { handleUpsertPushSubscription } from '../handlers/push/post';
+import { handleDeletePushSubscription } from '../handlers/push/delete';
 import type { AppContext } from '../context';
 import { createErrorDataWithLogging } from "../utils/api-helpers";
 
@@ -141,6 +143,13 @@ function createSessionSetRoutes(): Hono<AppContext> {
     .patch('/:setId/reset', requiredAuthMiddleware, handleResetSessionSet);
 }
 
+// /api/push/subscriptions
+function createPushRoutes(): Hono<AppContext> {
+  return new Hono<AppContext>()
+    .post('/subscriptions', requiredAuthMiddleware, handleUpsertPushSubscription)
+    .delete('/subscriptions', requiredAuthMiddleware, handleDeletePushSubscription);
+}
+
 // Handles health check endpoint
 function handleHealthEndpoint(c: Context) {
   return c.json({ status: 'ok', timestamp: new Date().toISOString() });
@@ -165,6 +174,7 @@ routes.route('/exercises', createExerciseRoutes());
 routes.route('/profiles', createProfileRoutes());
 routes.route('/plans', createPlanRoutes());
 routes.route('/sessions', createSessionRoutes());
+routes.route('/push', createPushRoutes());
 routes.get('/health', handleHealthEndpoint);
 routes.notFound(handleNotFound);
 routes.onError(handleOnError);

--- a/apps/api/src/repositories/push-subscription.repository.spec.ts
+++ b/apps/api/src/repositories/push-subscription.repository.spec.ts
@@ -1,0 +1,61 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database, PushSubscriptionDto } from '@txg/shared';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PushSubscriptionRepository } from './push-subscription.repository';
+
+const USER_ID = 'user-1';
+
+describe('PushSubscriptionRepository', () => {
+  let repository: PushSubscriptionRepository;
+  let from: ReturnType<typeof vi.fn>;
+  let upsert: ReturnType<typeof vi.fn>;
+  let select: ReturnType<typeof vi.fn>;
+  let single: ReturnType<typeof vi.fn>;
+  let del: ReturnType<typeof vi.fn>;
+  let eq1: ReturnType<typeof vi.fn>;
+  let eq2: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    single = vi.fn();
+    select = vi.fn(() => ({ single }));
+    upsert = vi.fn(() => ({ select }));
+
+    eq2 = vi.fn();
+    eq1 = vi.fn(() => ({ eq: eq2 }));
+    del = vi.fn(() => ({ eq: eq1 }));
+
+    from = vi.fn(() => ({ upsert, delete: del }));
+
+    const supabase = { from } as unknown as SupabaseClient<Database>;
+    repository = new PushSubscriptionRepository(supabase, () => USER_ID);
+  });
+
+  it('upserts the subscription mapped to columns, keyed on endpoint', async () => {
+    const row = { id: 's1', user_id: USER_ID, endpoint: 'https://push/1', p256dh: 'p', auth: 'a', created_at: 't' } as PushSubscriptionDto;
+    single.mockResolvedValue({ data: row, error: null });
+
+    const result = await repository.upsert({ endpoint: 'https://push/1', keys: { p256dh: 'p', auth: 'a' } });
+
+    expect(from).toHaveBeenCalledWith('push_subscriptions');
+    expect(upsert).toHaveBeenCalledWith(
+      { user_id: USER_ID, endpoint: 'https://push/1', p256dh: 'p', auth: 'a' },
+      { onConflict: 'endpoint' },
+    );
+    expect(result).toBe(row);
+  });
+
+  it('throws when the upsert fails', async () => {
+    single.mockResolvedValue({ data: null, error: new Error('db down') });
+    await expect(repository.upsert({ endpoint: 'https://push/1', keys: { p256dh: 'p', auth: 'a' } })).rejects.toThrow('db down');
+  });
+
+  it('deletes by endpoint scoped to the current user', async () => {
+    eq2.mockResolvedValue({ error: null });
+
+    await repository.deleteByEndpoint('https://push/1');
+
+    expect(del).toHaveBeenCalled();
+    expect(eq1).toHaveBeenCalledWith('user_id', USER_ID);
+    expect(eq2).toHaveBeenCalledWith('endpoint', 'https://push/1');
+  });
+});

--- a/apps/api/src/repositories/push-subscription.repository.ts
+++ b/apps/api/src/repositories/push-subscription.repository.ts
@@ -1,0 +1,64 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database, PushSubscriptionDto, UpsertPushSubscriptionCommand } from '@txg/shared';
+import { ApiErrorResponse } from '../utils/api-helpers';
+
+export class PushSubscriptionRepository {
+  constructor(
+    private supabase: SupabaseClient<Database>,
+    private getUserId: () => string
+  ) {}
+
+  /**
+   * Registers (or refreshes) a Web Push subscription for the current user.
+   * Keyed by the browser `endpoint`, so re-subscribing the same device updates in place.
+   *
+   * @param {UpsertPushSubscriptionCommand} command - The browser push subscription payload.
+   * @returns {Promise<PushSubscriptionDto>} The stored subscription.
+   */
+  async upsert(command: UpsertPushSubscriptionCommand): Promise<PushSubscriptionDto> {
+    const { data, error } = await this.supabase
+      .from('push_subscriptions')
+      .upsert(
+        {
+          user_id: this.getUserId(),
+          endpoint: command.endpoint,
+          p256dh: command.keys.p256dh,
+          auth: command.keys.auth,
+        },
+        { onConflict: 'endpoint' }
+      )
+      .select()
+      .single();
+
+    if (error) {
+      throw error;
+    }
+
+    return data as PushSubscriptionDto;
+  }
+
+  /**
+   * Removes a subscription for the current user by its endpoint (e.g. on unsubscribe).
+   *
+   * @param {string} endpoint - The push endpoint to remove.
+   */
+  async deleteByEndpoint(endpoint: string): Promise<void> {
+    const { error } = await this.supabase
+      .from('push_subscriptions')
+      .delete()
+      .eq('user_id', this.getUserId())
+      .eq('endpoint', endpoint);
+
+    if (error) {
+      throw error;
+    }
+  }
+
+  /**
+   * Placeholder for subscription-specific error mapping; there are no bespoke
+   * cases yet, so callers fall through to the generic server error.
+   */
+  handlePushSubscriptionError(): ApiErrorResponse | null {
+    return null;
+  }
+}

--- a/apps/api/src/services/push/push-sender.spec.ts
+++ b/apps/api/src/services/push/push-sender.spec.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { shouldSendSessionAlert } from './push-sender';
+
+describe('shouldSendSessionAlert', () => {
+  it('sends when the session is in progress and there is no newer activity', () => {
+    expect(shouldSendSessionAlert({ sessionStatus: 'IN_PROGRESS', hasNewerActivity: false })).toBe(true);
+  });
+
+  it('skips when the session is no longer in progress', () => {
+    expect(shouldSendSessionAlert({ sessionStatus: 'COMPLETED', hasNewerActivity: false })).toBe(false);
+    expect(shouldSendSessionAlert({ sessionStatus: 'CANCELLED', hasNewerActivity: false })).toBe(false);
+    expect(shouldSendSessionAlert({ sessionStatus: null, hasNewerActivity: false })).toBe(false);
+  });
+
+  it('skips a stale alert when the user has logged something since it was scheduled', () => {
+    expect(shouldSendSessionAlert({ sessionStatus: 'IN_PROGRESS', hasNewerActivity: true })).toBe(false);
+  });
+});

--- a/apps/api/src/services/push/push-sender.ts
+++ b/apps/api/src/services/push/push-sender.ts
@@ -1,0 +1,98 @@
+import { sendNotification } from 'web-push';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database, PushSubscriptionDto } from '@txg/shared';
+import type { SessionAlertMessage } from './session-alert.types';
+import { buildSessionAlertNotification } from './session-alert-notification';
+
+export interface SessionAlertContext {
+  sessionStatus: string | null;
+  hasNewerActivity: boolean;
+}
+
+/**
+ * Decides whether a scheduled alert is still worth delivering: only when the
+ * session is still in progress and the user has not logged anything since it
+ * was scheduled (which would make the alert stale).
+ */
+export function shouldSendSessionAlert(context: SessionAlertContext): boolean {
+  if (context.sessionStatus !== 'IN_PROGRESS') {
+    return false;
+  }
+  if (context.hasNewerActivity) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Validates a queued session alert against live state and, if still relevant,
+ * delivers it to all of the user's push subscriptions. Stale endpoints
+ * (404/410) are pruned.
+ */
+export async function processSessionAlert(
+  supabase: SupabaseClient<Database>,
+  message: SessionAlertMessage
+): Promise<void> {
+  const context = await loadAlertContext(supabase, message);
+  if (!shouldSendSessionAlert(context)) {
+    return;
+  }
+
+  const { data: subscriptions } = await supabase
+    .from('push_subscriptions')
+    .select('*')
+    .eq('user_id', message.userId);
+
+  if (!subscriptions || subscriptions.length === 0) {
+    return;
+  }
+
+  const payload = JSON.stringify({ notification: buildSessionAlertNotification(message) });
+  await Promise.all(subscriptions.map(subscription => sendToSubscription(supabase, subscription, payload)));
+}
+
+async function loadAlertContext(
+  supabase: SupabaseClient<Database>,
+  message: SessionAlertMessage
+): Promise<SessionAlertContext> {
+  const { data: session } = await supabase
+    .from('sessions')
+    .select('status')
+    .eq('id', message.sessionId)
+    .eq('user_id', message.userId)
+    .maybeSingle();
+
+  if (!session) {
+    return { sessionStatus: null, hasNewerActivity: false };
+  }
+
+  const { data: newerSets } = await supabase
+    .from('session_sets')
+    .select('id')
+    .eq('session_id', message.sessionId)
+    .gt('completed_at', message.scheduledFromIso)
+    .limit(1);
+
+  return {
+    sessionStatus: session.status,
+    hasNewerActivity: !!newerSets && newerSets.length > 0,
+  };
+}
+
+async function sendToSubscription(
+  supabase: SupabaseClient<Database>,
+  subscription: PushSubscriptionDto,
+  payload: string
+): Promise<void> {
+  try {
+    await sendNotification(
+      { endpoint: subscription.endpoint, keys: { p256dh: subscription.p256dh, auth: subscription.auth } },
+      payload
+    );
+  } catch (e) {
+    const statusCode = (e as { statusCode?: number }).statusCode;
+    if (statusCode === 404 || statusCode === 410) {
+      await supabase.from('push_subscriptions').delete().eq('id', subscription.id);
+    }
+  }
+}

--- a/apps/api/src/services/push/session-alert-message.spec.ts
+++ b/apps/api/src/services/push/session-alert-message.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { parseSessionAlertMessage } from './session-alert-message';
+
+const valid = {
+  type: 'rest-over',
+  userId: 'u1',
+  sessionId: 's1',
+  setId: 'set1',
+  scheduledFromIso: '2026-07-05T10:00:00.000Z',
+};
+
+describe('parseSessionAlertMessage', () => {
+  it('parses a valid object message', () => {
+    expect(parseSessionAlertMessage(valid)).toEqual(valid);
+  });
+
+  it('parses a valid JSON string message (base64-decoded by the host)', () => {
+    expect(parseSessionAlertMessage(JSON.stringify(valid))).toEqual(valid);
+  });
+
+  it('rejects an unknown alert type', () => {
+    expect(parseSessionAlertMessage({ ...valid, type: 'bogus' })).toBeNull();
+  });
+
+  it('rejects messages missing required fields', () => {
+    expect(parseSessionAlertMessage({ type: 'reminder', userId: 'u1' })).toBeNull();
+    expect(parseSessionAlertMessage('not json')).toBeNull();
+    expect(parseSessionAlertMessage(null)).toBeNull();
+  });
+});

--- a/apps/api/src/services/push/session-alert-message.ts
+++ b/apps/api/src/services/push/session-alert-message.ts
@@ -1,0 +1,39 @@
+import type { SessionAlertMessage, SessionAlertType } from './session-alert.types';
+
+/** Parses and validates a queue message into a SessionAlertMessage, or null if malformed. */
+export function parseSessionAlertMessage(queueItem: unknown): SessionAlertMessage | null {
+  const raw = typeof queueItem === 'string' ? safeParse(queueItem) : queueItem;
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+
+  const message = raw as Record<string, unknown>;
+  const type = message['type'];
+  if (type !== 'rest-over' && type !== 'reminder') {
+    return null;
+  }
+  if (
+    typeof message['userId'] !== 'string' ||
+    typeof message['sessionId'] !== 'string' ||
+    typeof message['setId'] !== 'string' ||
+    typeof message['scheduledFromIso'] !== 'string'
+  ) {
+    return null;
+  }
+
+  return {
+    type: type as SessionAlertType,
+    userId: message['userId'],
+    sessionId: message['sessionId'],
+    setId: message['setId'],
+    scheduledFromIso: message['scheduledFromIso'],
+  };
+}
+
+function safeParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}

--- a/apps/api/src/services/push/session-alert-notification.spec.ts
+++ b/apps/api/src/services/push/session-alert-notification.spec.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { buildSessionAlertNotification } from './session-alert-notification';
+import type { SessionAlertMessage } from './session-alert.types';
+
+const base: SessionAlertMessage = {
+  type: 'rest-over',
+  userId: 'u1',
+  sessionId: 'sess-1',
+  setId: 'set-1',
+  scheduledFromIso: '2026-07-05T10:00:00.000Z',
+};
+
+describe('buildSessionAlertNotification', () => {
+  it('builds a rest-over notification with quick actions bound to the session', () => {
+    const notification = buildSessionAlertNotification(base);
+
+    expect(notification.title).toBe('Rest over');
+    expect(notification.tag).toBe('session-active');
+    expect(notification.requireInteraction).toBe(true);
+    expect(notification.actions.map(a => a.action)).toEqual(['complete-set', 'reset-timer']);
+    expect(notification.data.onActionClick['complete-set'].url).toBe('/sessions/sess-1?action=complete-set');
+    expect(notification.data.onActionClick['default'].url).toBe('/sessions/sess-1');
+  });
+
+  it('builds a distinct reminder notification', () => {
+    const notification = buildSessionAlertNotification({ ...base, type: 'reminder' });
+    expect(notification.title).toBe('Still training?');
+  });
+});

--- a/apps/api/src/services/push/session-alert-notification.ts
+++ b/apps/api/src/services/push/session-alert-notification.ts
@@ -1,0 +1,54 @@
+import type { SessionAlertMessage } from './session-alert.types';
+
+const NOTIFICATION_TAG = 'session-active';
+const NOTIFICATION_ICON = '/assets/favicon/web-app-manifest-192x192.png';
+const VIBRATION_PATTERN = [400, 150, 400];
+
+// ngsw reads `data.onActionClick[action]` to focus/open the app on click.
+interface NgswActionClick {
+  operation: 'focusLastFocusedOrOpen';
+  url: string;
+}
+
+export interface SessionAlertNotification {
+  title: string;
+  body: string;
+  tag: string;
+  icon: string;
+  requireInteraction: boolean;
+  vibrate: number[];
+  actions: { action: string; title: string }[];
+  data: { onActionClick: Record<string, NgswActionClick> };
+}
+
+/**
+ * Builds the Web Push `notification` payload for a session alert. ngsw's push
+ * handler shows this directly, and the quick actions map back to the app via
+ * `?action=` (mirrors the client-side action map).
+ */
+export function buildSessionAlertNotification(message: SessionAlertMessage): SessionAlertNotification {
+  const isReminder = message.type === 'reminder';
+  const url = `/sessions/${message.sessionId}`;
+
+  return {
+    title: isReminder ? 'Still training?' : 'Rest over',
+    body: isReminder
+      ? 'Log your next set to keep your session going.'
+      : 'Time for your next set.',
+    tag: NOTIFICATION_TAG,
+    icon: NOTIFICATION_ICON,
+    requireInteraction: true,
+    vibrate: VIBRATION_PATTERN,
+    actions: [
+      { action: 'complete-set', title: 'Complete set' },
+      { action: 'reset-timer', title: 'Stop timer' },
+    ],
+    data: {
+      onActionClick: {
+        default: { operation: 'focusLastFocusedOrOpen', url },
+        'complete-set': { operation: 'focusLastFocusedOrOpen', url: `${url}?action=complete-set` },
+        'reset-timer': { operation: 'focusLastFocusedOrOpen', url: `${url}?action=reset-timer` },
+      },
+    },
+  };
+}

--- a/apps/api/src/services/push/session-alert-queue.ts
+++ b/apps/api/src/services/push/session-alert-queue.ts
@@ -1,0 +1,33 @@
+import { QueueClient } from '@azure/storage-queue';
+import type { SessionAlertMessage } from './session-alert.types';
+
+const QUEUE_NAME = 'session-alerts';
+
+// Azure Functions' queue trigger decodes messages as base64 by default, so the
+// queue client base64-encodes the JSON payload to match.
+let queueClient: QueueClient | undefined;
+
+function getQueueClient(): QueueClient {
+  if (!queueClient) {
+    queueClient = new QueueClient(process.env['AzureWebJobsStorage'] ?? '', QUEUE_NAME);
+  }
+  return queueClient;
+}
+
+/**
+ * Schedules a session alert for delivery after `delaySeconds` using the queue's
+ * visibility timeout. The queue-trigger function picks it up when it becomes
+ * visible and re-validates it before sending.
+ */
+export async function enqueueSessionAlert(message: SessionAlertMessage, delaySeconds: number): Promise<void> {
+  const client = getQueueClient();
+  await client.createIfNotExists();
+
+  const encoded = Buffer.from(JSON.stringify(message)).toString('base64');
+  await client.sendMessage(encoded, { visibilityTimeout: delaySeconds });
+}
+
+/** Resets the memoized client (used by tests). */
+export function resetSessionAlertQueueClient(): void {
+  queueClient = undefined;
+}

--- a/apps/api/src/services/push/session-alert-scheduler.ts
+++ b/apps/api/src/services/push/session-alert-scheduler.ts
@@ -1,0 +1,31 @@
+import { enqueueSessionAlert } from './session-alert-queue';
+
+// Rest thresholds (seconds) after which the "rest over" alert fires, plus the
+// idle reminder cadence that keeps sessions from being left open.
+export const REST_OVER_COMPLETE_SECONDS = 2 * 60;
+export const REST_OVER_FAIL_SECONDS = 5 * 60;
+const REMINDER_SECONDS = 15 * 60;
+
+/**
+ * Schedules the delayed rest-over and idle-reminder alerts for a set that was
+ * just completed/failed. Best-effort: a queue failure must never break the
+ * originating request, so errors are swallowed here.
+ */
+export async function scheduleRestAlerts(
+  userId: string,
+  sessionId: string,
+  setId: string,
+  restOverSeconds: number
+): Promise<void> {
+  const scheduledFromIso = new Date().toISOString();
+  const base = { userId, sessionId, setId, scheduledFromIso };
+
+  try {
+    await Promise.all([
+      enqueueSessionAlert({ ...base, type: 'rest-over' }, restOverSeconds),
+      enqueueSessionAlert({ ...base, type: 'reminder' }, REMINDER_SECONDS),
+    ]);
+  } catch (e) {
+    console.error('Failed to schedule session alerts', e);
+  }
+}

--- a/apps/api/src/services/push/session-alert.types.ts
+++ b/apps/api/src/services/push/session-alert.types.ts
@@ -1,0 +1,11 @@
+/** A delayed session notification carried on the `session-alerts` storage queue. */
+export type SessionAlertType = 'rest-over' | 'reminder';
+
+export interface SessionAlertMessage {
+  type: SessionAlertType;
+  userId: string;
+  sessionId: string;
+  setId: string;
+  /** When the alert was scheduled; used to skip it if the user has since acted. */
+  scheduledFromIso: string;
+}

--- a/apps/api/src/utils/supabase-admin.ts
+++ b/apps/api/src/utils/supabase-admin.ts
@@ -1,0 +1,20 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@txg/shared';
+
+/**
+ * Creates a Supabase client authenticated with the service-role (secret) key.
+ *
+ * Intended ONLY for background workers (e.g. the push queue trigger) that run
+ * without a user JWT and must read across users. This bypasses RLS, so it must
+ * never be used in request-scoped handlers — those use the publishable key plus
+ * the caller's JWT via `supabaseMiddleware`.
+ */
+export function createAdminSupabaseClient(): SupabaseClient<Database> {
+  return createClient<Database>(
+    process.env['SUPABASE_URL'] ?? '',
+    process.env['SUPABASE_SECRET_KEY'] ?? '',
+    {
+      auth: { persistSession: false, autoRefreshToken: false },
+    }
+  );
+}

--- a/apps/web/angular.json
+++ b/apps/web/angular.json
@@ -79,7 +79,8 @@
                 }
               ],
               "outputHashing": "all",
-              "sourceMap": true
+              "sourceMap": true,
+              "serviceWorker": "ngsw-config.json"
             },
             "development": {
               "fileReplacements": [

--- a/apps/web/src/app/features/sessions/models/session-page.selectors.spec.ts
+++ b/apps/web/src/app/features/sessions/models/session-page.selectors.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { selectCurrentSet } from './session-page.selectors';
+import { SessionPageViewModel, SessionSetViewModel } from './session-page.viewmodel';
+
+const set = (over: Partial<SessionSetViewModel>): SessionSetViewModel => ({
+  id: 'set',
+  planExerciseId: 'ex',
+  order: 1,
+  status: 'PENDING',
+  expectedReps: 5,
+  ...over,
+});
+
+const viewModel = (exercises: SessionPageViewModel['exercises']): SessionPageViewModel => ({
+  id: 's1',
+  isLoading: false,
+  error: null,
+  metadata: {},
+  exercises,
+});
+
+describe('selectCurrentSet', () => {
+  it('returns the first PENDING set of the first exercise (by order)', () => {
+    const vm = viewModel([
+      { planExerciseId: 'b', exerciseName: 'Bench', order: 2, plannedSetsCount: 1, sets: [set({ id: 'b1', order: 1 })] },
+      {
+        planExerciseId: 'a', exerciseName: 'Squat', order: 1, plannedSetsCount: 2,
+        sets: [set({ id: 'a1', order: 1, status: 'COMPLETED' }), set({ id: 'a2', order: 2 })],
+      },
+    ]);
+
+    const current = selectCurrentSet(vm);
+
+    expect(current?.exercise.exerciseName).toBe('Squat');
+    expect(current?.set.id).toBe('a2');
+  });
+
+  it('skips fully-completed exercises', () => {
+    const vm = viewModel([
+      {
+        planExerciseId: 'a', exerciseName: 'Squat', order: 1, plannedSetsCount: 1,
+        sets: [set({ id: 'a1', order: 1, status: 'COMPLETED' })],
+      },
+      { planExerciseId: 'b', exerciseName: 'Bench', order: 2, plannedSetsCount: 1, sets: [set({ id: 'b1', order: 1 })] },
+    ]);
+
+    expect(selectCurrentSet(vm)?.set.id).toBe('b1');
+  });
+
+  it('returns null when no pending sets remain', () => {
+    const vm = viewModel([
+      {
+        planExerciseId: 'a', exerciseName: 'Squat', order: 1, plannedSetsCount: 1,
+        sets: [set({ id: 'a1', order: 1, status: 'FAILED' })],
+      },
+    ]);
+
+    expect(selectCurrentSet(vm)).toBeNull();
+  });
+});

--- a/apps/web/src/app/features/sessions/models/session-page.selectors.ts
+++ b/apps/web/src/app/features/sessions/models/session-page.selectors.ts
@@ -1,0 +1,27 @@
+import { SessionExerciseViewModel, SessionPageViewModel, SessionSetViewModel } from './session-page.viewmodel';
+
+export interface CurrentSetSelection {
+  exercise: SessionExerciseViewModel;
+  set: SessionSetViewModel;
+}
+
+/**
+ * The next set the user should perform: the first `PENDING` set (by order)
+ * within the first exercise (by order) that still has a pending set. Returns
+ * null when every set has been completed/failed/skipped.
+ */
+export function selectCurrentSet(viewModel: SessionPageViewModel): CurrentSetSelection | null {
+  const exercises = [...viewModel.exercises].sort((a, b) => a.order - b.order);
+
+  for (const exercise of exercises) {
+    const set = [...exercise.sets]
+      .sort((a, b) => a.order - b.order)
+      .find(candidate => candidate.status === 'PENDING');
+
+    if (set) {
+      return { exercise, set };
+    }
+  }
+
+  return null;
+}

--- a/apps/web/src/app/features/sessions/models/session-page.viewmodel.ts
+++ b/apps/web/src/app/features/sessions/models/session-page.viewmodel.ts
@@ -33,3 +33,14 @@ export interface SessionSetViewModel {
   actualReps?: number | null;
   weight?: number;
 }
+
+/**
+ * Payload for the rest-timer reset trigger. `timestamp` restarts the timer on
+ * every set interaction; `vibrateAfterSeconds` is the rest threshold at which
+ * the device should buzz (null when the interaction should not schedule a buzz,
+ * e.g. un-marking a set back to PENDING).
+ */
+export interface SessionTimerReset {
+  timestamp: number;
+  vibrateAfterSeconds: number | null;
+}

--- a/apps/web/src/app/features/sessions/pages/session-page/components/session-timer/session-timer.component.spec.ts
+++ b/apps/web/src/app/features/sessions/pages/session-page/components/session-timer/session-timer.component.spec.ts
@@ -2,6 +2,12 @@ import { ChangeDetectorRef, NgZone, WritableSignal, signal, effect } from '@angu
 import { Subject, Subscription } from 'rxjs';
 import { vi, describe, it, expect, beforeEach, afterEach, MockedFunction } from 'vitest';
 import { SessionTimerComponent } from './session-timer.component';
+import { SessionTimerReset } from '../../../../models/session-page.viewmodel';
+
+const makeReset = (vibrateAfterSeconds: number | null = null): SessionTimerReset => ({
+  timestamp: Date.now(),
+  vibrateAfterSeconds,
+});
 
 // Define a type for our augmented effect mock
 interface CustomMockEffect extends MockedFunction<typeof effect> {
@@ -72,7 +78,7 @@ class TestableSessionTimerComponent extends SessionTimerComponent {
 
 describe('SessionTimerComponent', () => {
   let component: TestableSessionTimerComponent;
-  let mockResetTrigger: WritableSignal<number | null>;
+  let mockResetTrigger: WritableSignal<SessionTimerReset | null>;
   let spiedEffect: CustomMockEffect;
 
   beforeEach(() => {
@@ -86,7 +92,7 @@ describe('SessionTimerComponent', () => {
       runOutsideAngular: vi.fn((fn) => fn()),
     } as unknown as NgZone;
 
-    mockResetTrigger = signal<number | null>(null);
+    mockResetTrigger = signal<SessionTimerReset | null>(null);
     component = new TestableSessionTimerComponent();
 
     component.resetTrigger = mockResetTrigger;
@@ -115,9 +121,8 @@ describe('SessionTimerComponent', () => {
   });
 
   describe('resetTrigger Effect', () => {
-    it('should start timer and pulse when resetTrigger emits a number', () => {
-      const resetTime = Date.now();
-      mockResetTrigger.set(resetTime);
+    it('should start timer and pulse when resetTrigger emits a value', () => {
+      mockResetTrigger.set(makeReset());
       triggerEffectManually();
       vi.advanceTimersByTime(0);
 
@@ -133,7 +138,7 @@ describe('SessionTimerComponent', () => {
     });
 
     it('should reset and stop timer when resetTrigger emits null after being a number', () => {
-      mockResetTrigger.set(Date.now());
+      mockResetTrigger.set(makeReset());
       triggerEffectManually();
       vi.advanceTimersByTime(2000);
       expect(component.testSecondsElapsed).toBe(2);
@@ -163,7 +168,7 @@ describe('SessionTimerComponent', () => {
     });
 
     it('should be "--:--" when allExercisesComplete is true, even if timer was running', () => {
-      mockResetTrigger.set(Date.now());
+      mockResetTrigger.set(makeReset());
       triggerEffectManually();
       vi.advanceTimersByTime(1000);
       expect(component.timerText).toBe('00:01');
@@ -174,35 +179,35 @@ describe('SessionTimerComponent', () => {
     });
 
     it('should format time correctly (0 seconds)', () => {
-      mockResetTrigger.set(Date.now());
+      mockResetTrigger.set(makeReset());
       triggerEffectManually();
       vi.advanceTimersByTime(0);
       expect(component.timerText).toBe('00:00');
     });
 
     it('should format time correctly (59 seconds)', () => {
-      mockResetTrigger.set(Date.now());
+      mockResetTrigger.set(makeReset());
       triggerEffectManually();
       vi.advanceTimersByTime(59 * 1000);
       expect(component.timerText).toBe('00:59');
     });
 
     it('should format time correctly (1 minute)', () => {
-      mockResetTrigger.set(Date.now());
+      mockResetTrigger.set(makeReset());
       triggerEffectManually();
       vi.advanceTimersByTime(60 * 1000);
       expect(component.timerText).toBe('01:00');
     });
 
     it('should format time correctly (2 minutes and 5 seconds)', () => {
-      mockResetTrigger.set(Date.now());
+      mockResetTrigger.set(makeReset());
       triggerEffectManually();
       vi.advanceTimersByTime(2 * 60 * 1000 + 5 * 1000);
       expect(component.timerText).toBe('02:05');
     });
 
     it('should format time correctly (100 minutes and 10 seconds)', () => {
-      mockResetTrigger.set(Date.now());
+      mockResetTrigger.set(makeReset());
       triggerEffectManually();
       vi.advanceTimersByTime(100 * 60 * 1000 + 10 * 1000);
       expect(component.timerText).toBe('100:10');
@@ -212,7 +217,7 @@ describe('SessionTimerComponent', () => {
   describe('allExercisesComplete Input', () => {
     it('should update timerText to "--:--" when true and timer is active', () => {
       (currentMockCdr.markForCheck as MockedFunction<() => void>).mockClear();
-      mockResetTrigger.set(Date.now());
+      mockResetTrigger.set(makeReset());
       triggerEffectManually(); // Effect runs: resetTimer (MFC#1), startTimer, triggerPulse (MFC#2)
       expect(currentMockCdr.markForCheck).toHaveBeenCalledTimes(2);
 
@@ -230,7 +235,7 @@ describe('SessionTimerComponent', () => {
 
     it('should revert timerText when false and timer is active', () => {
       (currentMockCdr.markForCheck as MockedFunction<() => void>).mockClear();
-      mockResetTrigger.set(Date.now());
+      mockResetTrigger.set(makeReset());
       triggerEffectManually(); // Effect runs: resetTimer (MFC#1), startTimer, triggerPulse (MFC#2)
       expect(currentMockCdr.markForCheck).toHaveBeenCalledTimes(2);
 
@@ -301,7 +306,7 @@ describe('SessionTimerComponent', () => {
 
   describe('Timer Mechanics', () => {
     it('startTimer should increment secondsElapsed', () => {
-      mockResetTrigger.set(Date.now());
+      mockResetTrigger.set(makeReset());
       triggerEffectManually();
       vi.advanceTimersByTime(0);
       expect(component.testSecondsElapsed).toBe(0);
@@ -312,7 +317,7 @@ describe('SessionTimerComponent', () => {
     });
 
     it('stopTimer should stop incrementing secondsElapsed', () => {
-      mockResetTrigger.set(Date.now());
+      mockResetTrigger.set(makeReset());
       triggerEffectManually();
       vi.advanceTimersByTime(2000);
       expect(component.testSecondsElapsed).toBe(2);
@@ -323,7 +328,7 @@ describe('SessionTimerComponent', () => {
     });
 
     it('resetTimer should set secondsElapsed to 0 and stop timer', () => {
-      mockResetTrigger.set(Date.now());
+      mockResetTrigger.set(makeReset());
       triggerEffectManually();
       vi.advanceTimersByTime(3000);
       expect(component.testSecondsElapsed).toBe(3);
@@ -333,6 +338,64 @@ describe('SessionTimerComponent', () => {
       expect(component.testTimerSubscription).toBeUndefined();
       vi.advanceTimersByTime(2000);
       expect(component.testSecondsElapsed).toBe(0);
+    });
+  });
+
+  describe('rest-over vibration', () => {
+    let vibrateSpy: MockedFunction<(pattern: number | number[]) => boolean>;
+
+    beforeEach(() => {
+      vibrateSpy = vi.fn(() => true);
+      Object.defineProperty(navigator, 'vibrate', { value: vibrateSpy, configurable: true, writable: true });
+    });
+
+    afterEach(() => {
+      delete (navigator as unknown as { vibrate?: unknown }).vibrate;
+    });
+
+    it('should vibrate once at the COMPLETED threshold (120s)', () => {
+      mockResetTrigger.set(makeReset(120));
+      triggerEffectManually();
+
+      vi.advanceTimersByTime(119 * 1000);
+      expect(vibrateSpy).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1000); // 120s
+      expect(vibrateSpy).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(60 * 1000);
+      expect(vibrateSpy).toHaveBeenCalledTimes(1); // only once per rest period
+    });
+
+    it('should vibrate at the FAILED threshold (300s)', () => {
+      mockResetTrigger.set(makeReset(300));
+      triggerEffectManually();
+
+      vi.advanceTimersByTime(299 * 1000);
+      expect(vibrateSpy).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1000); // 300s
+      expect(vibrateSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not vibrate when vibrateAfterSeconds is null', () => {
+      mockResetTrigger.set(makeReset(null));
+      triggerEffectManually();
+
+      vi.advanceTimersByTime(10 * 60 * 1000);
+      expect(vibrateSpy).not.toHaveBeenCalled();
+    });
+
+    it('should re-arm the buzz on the next reset', () => {
+      mockResetTrigger.set(makeReset(120));
+      triggerEffectManually();
+      vi.advanceTimersByTime(120 * 1000);
+      expect(vibrateSpy).toHaveBeenCalledTimes(1);
+
+      mockResetTrigger.set(makeReset(120));
+      triggerEffectManually();
+      vi.advanceTimersByTime(120 * 1000);
+      expect(vibrateSpy).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -346,7 +409,7 @@ describe('SessionTimerComponent', () => {
     });
 
     it('should effectively stop the timer', () => { // Renamed test for clarity
-      mockResetTrigger.set(Date.now());
+      mockResetTrigger.set(makeReset());
       triggerEffectManually();
       vi.advanceTimersByTime(1000);
       expect(component.testSecondsElapsed).toBe(1);

--- a/apps/web/src/app/features/sessions/pages/session-page/components/session-timer/session-timer.component.ts
+++ b/apps/web/src/app/features/sessions/pages/session-page/components/session-timer/session-timer.component.ts
@@ -4,6 +4,10 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatIconModule } from '@angular/material/icon';
 import { Subscription, Subject, takeUntil, interval } from 'rxjs';
+import { SessionTimerReset } from '../../../../models/session-page.viewmodel';
+
+// Distinct "rest over" haptic pattern (buzz–pause–buzz), in milliseconds.
+const REST_OVER_VIBRATION_PATTERN = [400, 150, 400];
 
 @Component({
   selector: 'txg-session-timer',
@@ -14,7 +18,7 @@ import { Subscription, Subject, takeUntil, interval } from 'rxjs';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SessionTimerComponent implements OnDestroy {
-  @Input({ required: true }) resetTrigger!: Signal<number | null | undefined>;
+  @Input({ required: true }) resetTrigger!: Signal<SessionTimerReset | null | undefined>;
   @Input() @HostBinding('class.all-sets-complete-highlight') allExercisesComplete: boolean = false;
 
   @Output() readonly sessionCompleted = new EventEmitter<void>();
@@ -27,6 +31,8 @@ export class SessionTimerComponent implements OnDestroy {
   private pulseTimeoutId: ReturnType<typeof setTimeout> | null = null;
   private secondsElapsed: number = 0;
   private timerSubscription: Subscription | undefined;
+  private vibrateAfterSeconds: number | null = null;
+  private hasVibrated: boolean = false;
 
   get timerText(): string {
     if (this.timerSubscription === undefined || this.allExercisesComplete) {
@@ -48,6 +54,7 @@ export class SessionTimerComponent implements OnDestroy {
       } else {
         untracked(() => {
           this.resetTimer();
+          this.vibrateAfterSeconds = triggerValue.vibrateAfterSeconds;
           this.startTimer();
           this.triggerPulse();
         });
@@ -92,6 +99,7 @@ export class SessionTimerComponent implements OnDestroy {
         .subscribe(() => {
           this.ngZone.run(() => {
             this.secondsElapsed++;
+            this.maybeVibrateRestOver();
             this.cdr.markForCheck();
           });
         });
@@ -105,7 +113,28 @@ export class SessionTimerComponent implements OnDestroy {
 
   private resetTimer(): void {
     this.secondsElapsed = 0;
+    this.vibrateAfterSeconds = null;
+    this.hasVibrated = false;
     this.stopTimer();
     this.cdr.markForCheck();
+  }
+
+  private maybeVibrateRestOver(): void {
+    if (this.hasVibrated || this.vibrateAfterSeconds === null) {
+      return;
+    }
+    if (this.secondsElapsed < this.vibrateAfterSeconds) {
+      return;
+    }
+
+    this.hasVibrated = true;
+    this.vibrate(REST_OVER_VIBRATION_PATTERN);
+    this.triggerPulse();
+  }
+
+  private vibrate(pattern: number[]): void {
+    if (typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function') {
+      navigator.vibrate(pattern);
+    }
   }
 }

--- a/apps/web/src/app/features/sessions/pages/session-page/session-page.component.ts
+++ b/apps/web/src/app/features/sessions/pages/session-page/session-page.component.ts
@@ -4,15 +4,15 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router, ActivatedRoute } from '@angular/router';
-import { Observable, of, Subject } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { CreateSessionSetCommand, UpdateSessionSetCommand } from '@txg/shared';
-import { concatMap, filter, map, switchMap } from 'rxjs/operators';
+import { filter, map, switchMap } from 'rxjs/operators';
 import { NoticeComponent } from '@shared/ui/components/notice/notice.component';
 import { ConfirmationDialogComponent, ConfirmationDialogData } from '@shared/ui/dialogs/confirmation-dialog/confirmation-dialog.component';
 import { MainLayoutComponent } from '@shared/ui/layouts/main-layout/main-layout.component';
 import { tapIf } from '@shared/utils/operators/tap-if.operator';
 import { selectCurrentSet } from '../../models/session-page.selectors';
-import { SessionPageViewModel, SessionSetViewModel } from '../../models/session-page.viewmodel';
+import { SessionSetViewModel } from '../../models/session-page.viewmodel';
 import { SessionNotificationAction, SessionNotificationService } from '../../shared/session-notification.service';
 import { AddEditSetDialogComponent, AddEditSetDialogData, AddEditSetDialogCloseResult, DeleteSetResult } from './components/dialogs/add-edit-set-dialog/add-edit-set-dialog.component';
 import { SessionExerciseListComponent } from './components/session-exercise-list/session-exercise-list.component';
@@ -47,10 +47,6 @@ export class SessionPageComponent implements OnDestroy {
 
   // A notification action captured on cold start, applied once the session loads.
   private readonly pendingAction = signal<SessionNotificationAction | null>(null);
-
-  // Serializes async notification updates so a later state always wins over an
-  // earlier one (concatMap waits for each show/clear to finish before the next).
-  private readonly notificationSync$ = new Subject<SessionPageViewModel>();
 
   readonly isLoadingSignal = computed(() => this.viewModel().isLoading);
 
@@ -90,20 +86,6 @@ export class SessionPageComponent implements OnDestroy {
       if (error) {
         this.snackBar.open(error, 'Close', { duration: 5000 });
       }
-    });
-
-    // Keep the ongoing OS notification in sync with the current set. The async
-    // updates run through a serialized stream to avoid overlapping show/clear.
-    this.notificationSync$
-      .pipe(
-        concatMap(viewModel => this.syncNotification(viewModel)),
-        takeUntilDestroyed(this.destroyRef),
-      )
-      .subscribe();
-
-    effect(() => {
-      const viewModel = this.viewModel();
-      this.notificationSync$.next(viewModel);
     });
 
     // Quick actions while the app is in the foreground (warm path).
@@ -270,32 +252,8 @@ export class SessionPageComponent implements OnDestroy {
     void this.notificationService.requestPermission().then(permission => {
       if (permission === 'granted') {
         void this.notificationService.subscribeToPush();
-        this.notificationSync$.next(this.viewModel());
       }
     });
-  }
-
-  private async syncNotification(viewModel: SessionPageViewModel): Promise<void> {
-    try {
-      const status = viewModel.metadata?.status;
-      const isActive = !!viewModel.id && status !== 'COMPLETED' && status !== 'CANCELLED';
-      const current = isActive ? selectCurrentSet(viewModel) : null;
-
-      if (!current) {
-        await this.notificationService.clear();
-        return;
-      }
-
-      await this.notificationService.show({
-        sessionId: viewModel.id!,
-        title: viewModel.metadata?.dayName || viewModel.metadata?.planName || 'Active workout',
-        exerciseName: current.exercise.exerciseName,
-        reps: current.set.expectedReps,
-        weight: current.set.weight,
-      });
-    } catch {
-      // Notifications are best-effort; keep the sync stream alive on failure.
-    }
   }
 
   private handleNotificationAction(action: SessionNotificationAction): void {

--- a/apps/web/src/app/features/sessions/pages/session-page/session-page.component.ts
+++ b/apps/web/src/app/features/sessions/pages/session-page/session-page.component.ts
@@ -4,9 +4,9 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router, ActivatedRoute } from '@angular/router';
-import { Observable, of } from 'rxjs';
+import { Observable, of, Subject } from 'rxjs';
 import { CreateSessionSetCommand, UpdateSessionSetCommand } from '@txg/shared';
-import { filter, map, switchMap } from 'rxjs/operators';
+import { concatMap, filter, map, switchMap } from 'rxjs/operators';
 import { NoticeComponent } from '@shared/ui/components/notice/notice.component';
 import { ConfirmationDialogComponent, ConfirmationDialogData } from '@shared/ui/dialogs/confirmation-dialog/confirmation-dialog.component';
 import { MainLayoutComponent } from '@shared/ui/layouts/main-layout/main-layout.component';
@@ -48,6 +48,10 @@ export class SessionPageComponent implements OnDestroy {
   // A notification action captured on cold start, applied once the session loads.
   private readonly pendingAction = signal<SessionNotificationAction | null>(null);
 
+  // Serializes async notification updates so a later state always wins over an
+  // earlier one (concatMap waits for each show/clear to finish before the next).
+  private readonly notificationSync$ = new Subject<SessionPageViewModel>();
+
   readonly isLoadingSignal = computed(() => this.viewModel().isLoading);
 
   readonly isReadOnly = computed(() => {
@@ -88,10 +92,18 @@ export class SessionPageComponent implements OnDestroy {
       }
     });
 
-    // Keep the ongoing OS notification in sync with the current set.
+    // Keep the ongoing OS notification in sync with the current set. The async
+    // updates run through a serialized stream to avoid overlapping show/clear.
+    this.notificationSync$
+      .pipe(
+        concatMap(viewModel => this.syncNotification(viewModel)),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+
     effect(() => {
       const viewModel = this.viewModel();
-      untracked(() => this.syncNotification(viewModel));
+      this.notificationSync$.next(viewModel);
     });
 
     // Quick actions while the app is in the foreground (warm path).
@@ -108,7 +120,7 @@ export class SessionPageComponent implements OnDestroy {
         if (action !== 'complete-set' && action !== 'reset-timer') return;
 
         this.pendingAction.set(action);
-        this.router.navigate([], { relativeTo: this.route, queryParams: {}, replaceUrl: true });
+        this.router.navigate([], { relativeTo: this.route, queryParams: { action: null }, queryParamsHandling: 'merge', replaceUrl: true });
       });
 
     // Apply a captured cold-start action once the session has finished loading.
@@ -257,28 +269,32 @@ export class SessionPageComponent implements OnDestroy {
   private requestNotificationPermission(): void {
     void this.notificationService.requestPermission().then(permission => {
       if (permission === 'granted') {
-        this.syncNotification(this.viewModel());
+        this.notificationSync$.next(this.viewModel());
       }
     });
   }
 
-  private syncNotification(viewModel: SessionPageViewModel): void {
-    const status = viewModel.metadata?.status;
-    const isActive = !!viewModel.id && status !== 'COMPLETED' && status !== 'CANCELLED';
-    const current = isActive ? selectCurrentSet(viewModel) : null;
+  private async syncNotification(viewModel: SessionPageViewModel): Promise<void> {
+    try {
+      const status = viewModel.metadata?.status;
+      const isActive = !!viewModel.id && status !== 'COMPLETED' && status !== 'CANCELLED';
+      const current = isActive ? selectCurrentSet(viewModel) : null;
 
-    if (!current) {
-      void this.notificationService.clear();
-      return;
+      if (!current) {
+        await this.notificationService.clear();
+        return;
+      }
+
+      await this.notificationService.show({
+        sessionId: viewModel.id!,
+        title: viewModel.metadata?.dayName || viewModel.metadata?.planName || 'Active workout',
+        exerciseName: current.exercise.exerciseName,
+        reps: current.set.expectedReps,
+        weight: current.set.weight,
+      });
+    } catch {
+      // Notifications are best-effort; keep the sync stream alive on failure.
     }
-
-    void this.notificationService.show({
-      sessionId: viewModel.id!,
-      title: viewModel.metadata?.dayName || viewModel.metadata?.planName || 'Active workout',
-      exerciseName: current.exercise.exerciseName,
-      reps: current.set.expectedReps,
-      weight: current.set.weight,
-    });
   }
 
   private handleNotificationAction(action: SessionNotificationAction): void {

--- a/apps/web/src/app/features/sessions/pages/session-page/session-page.component.ts
+++ b/apps/web/src/app/features/sessions/pages/session-page/session-page.component.ts
@@ -269,6 +269,7 @@ export class SessionPageComponent implements OnDestroy {
   private requestNotificationPermission(): void {
     void this.notificationService.requestPermission().then(permission => {
       if (permission === 'granted') {
+        void this.notificationService.subscribeToPush();
         this.notificationSync$.next(this.viewModel());
       }
     });

--- a/apps/web/src/app/features/sessions/pages/session-page/session-page.component.ts
+++ b/apps/web/src/app/features/sessions/pages/session-page/session-page.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, DestroyRef, effect, inject, OnDestroy } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, DestroyRef, effect, inject, OnDestroy, signal, untracked } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -11,7 +11,9 @@ import { NoticeComponent } from '@shared/ui/components/notice/notice.component';
 import { ConfirmationDialogComponent, ConfirmationDialogData } from '@shared/ui/dialogs/confirmation-dialog/confirmation-dialog.component';
 import { MainLayoutComponent } from '@shared/ui/layouts/main-layout/main-layout.component';
 import { tapIf } from '@shared/utils/operators/tap-if.operator';
-import { SessionSetViewModel } from '../../models/session-page.viewmodel';
+import { selectCurrentSet } from '../../models/session-page.selectors';
+import { SessionPageViewModel, SessionSetViewModel } from '../../models/session-page.viewmodel';
+import { SessionNotificationAction, SessionNotificationService } from '../../shared/session-notification.service';
 import { AddEditSetDialogComponent, AddEditSetDialogData, AddEditSetDialogCloseResult, DeleteSetResult } from './components/dialogs/add-edit-set-dialog/add-edit-set-dialog.component';
 import { SessionExerciseListComponent } from './components/session-exercise-list/session-exercise-list.component';
 import { SessionHeaderComponent } from './components/session-header/session-header.component';
@@ -38,9 +40,13 @@ export class SessionPageComponent implements OnDestroy {
   private snackBar = inject(MatSnackBar);
   private facade = inject(SessionPageFacade);
   private route = inject(ActivatedRoute);
+  private notificationService = inject(SessionNotificationService);
 
   readonly viewModel = this.facade.viewModel;
   readonly timerResetTrigger = this.facade.timerResetTrigger;
+
+  // A notification action captured on cold start, applied once the session loads.
+  private readonly pendingAction = signal<SessionNotificationAction | null>(null);
 
   readonly isLoadingSignal = computed(() => this.viewModel().isLoading);
 
@@ -81,6 +87,41 @@ export class SessionPageComponent implements OnDestroy {
         this.snackBar.open(error, 'Close', { duration: 5000 });
       }
     });
+
+    // Keep the ongoing OS notification in sync with the current set.
+    effect(() => {
+      const viewModel = this.viewModel();
+      untracked(() => this.syncNotification(viewModel));
+    });
+
+    // Quick actions while the app is in the foreground (warm path).
+    this.notificationService.actions$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(action => this.handleNotificationAction(action));
+
+    // Quick actions after a cold start: the tapped action arrives as a query
+    // param; capture it and strip it so a refresh cannot replay it.
+    this.route.queryParamMap
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(params => {
+        const action = params.get('action');
+        if (action !== 'complete-set' && action !== 'reset-timer') return;
+
+        this.pendingAction.set(action);
+        this.router.navigate([], { relativeTo: this.route, queryParams: {}, replaceUrl: true });
+      });
+
+    // Apply a captured cold-start action once the session has finished loading.
+    effect(() => {
+      const viewModel = this.viewModel();
+      const action = this.pendingAction();
+      if (!action || viewModel.isLoading || !viewModel.id) return;
+
+      untracked(() => {
+        this.pendingAction.set(null);
+        this.handleNotificationAction(action);
+      });
+    });
   }
 
   onSetClicked(event: { set: SessionSetViewModel; exerciseId: string }): void {
@@ -94,8 +135,9 @@ export class SessionPageComponent implements OnDestroy {
     const setInSignal = exercise.sets.find(s => s.id === setToUpdateTo.id)!;
     const originalSetStateForRevert = { ...setInSignal };
 
-    this.facade.triggerTimerReset();
+    this.facade.triggerTimerReset(setToUpdateTo.status);
     this.facade.enqueueSetPatch(setToUpdateTo, exerciseId, originalSetStateForRevert);
+    this.requestNotificationPermission();
   }
 
   onSetLongPressed(event: { set: SessionSetViewModel; exerciseId: string }): void {
@@ -208,7 +250,56 @@ export class SessionPageComponent implements OnDestroy {
 
   ngOnDestroy(): void {
     this.facade.flushPendingSetUpdate();
-    this.facade.triggerTimerReset(true);
+    this.facade.triggerTimerReset();
+    void this.notificationService.clear();
+  }
+
+  private requestNotificationPermission(): void {
+    void this.notificationService.requestPermission().then(permission => {
+      if (permission === 'granted') {
+        this.syncNotification(this.viewModel());
+      }
+    });
+  }
+
+  private syncNotification(viewModel: SessionPageViewModel): void {
+    const status = viewModel.metadata?.status;
+    const isActive = !!viewModel.id && status !== 'COMPLETED' && status !== 'CANCELLED';
+    const current = isActive ? selectCurrentSet(viewModel) : null;
+
+    if (!current) {
+      void this.notificationService.clear();
+      return;
+    }
+
+    void this.notificationService.show({
+      sessionId: viewModel.id!,
+      title: viewModel.metadata?.dayName || viewModel.metadata?.planName || 'Active workout',
+      exerciseName: current.exercise.exerciseName,
+      reps: current.set.expectedReps,
+      weight: current.set.weight,
+    });
+  }
+
+  private handleNotificationAction(action: SessionNotificationAction): void {
+    if (this.isReadOnly()) return;
+
+    if (action === 'reset-timer') {
+      this.facade.triggerTimerReset();
+      return;
+    }
+
+    const current = selectCurrentSet(this.viewModel());
+    if (!current) return;
+
+    const completedSet: SessionSetViewModel = {
+      ...current.set,
+      status: 'COMPLETED',
+      actualReps: current.set.expectedReps,
+    };
+
+    this.facade.triggerTimerReset('COMPLETED');
+    this.facade.enqueueSetPatch(completedSet, current.exercise.planExerciseId, { ...current.set });
   }
 
   private showSnackbar(message: string, duration: number = 3000): void {

--- a/apps/web/src/app/features/sessions/pages/session-page/session-page.facade.ts
+++ b/apps/web/src/app/features/sessions/pages/session-page/session-page.facade.ts
@@ -8,9 +8,9 @@ import { ExerciseService } from '@shared/api/exercise.service';
 import { KeyedDebouncerService, DebouncerSuccessEvent, DebouncerFailureEvent } from '@shared/services/keyed-debouncer.service';
 import { tapIf } from '@shared/utils/operators/tap-if.operator';
 import { SessionService } from '../../api/session.service';
-import { SessionPageViewModel, SessionSetViewModel } from '../../models/session-page.viewmodel';
+import { SessionPageViewModel, SessionSetViewModel, SessionTimerReset } from '../../models/session-page.viewmodel';
 import { mapToSessionPageViewModel, mapToSessionSetViewModel } from '../../models/session.mapping';
-import { SessionStatus } from '../../models/session.types';
+import { SessionSetStatus, SessionStatus } from '../../models/session.types';
 
 // Types used by KeyedDebouncerService for session set update operations
 type SessionSetUpdateSuccessDataContext = { exerciseId: string; originalExpectedReps: number | null };
@@ -26,6 +26,13 @@ const initialState: SessionPageViewModel = {
   metadata: {},
 };
 
+// Rest thresholds (seconds) after which the device buzzes, keyed by the
+// resulting set status. Statuses without an entry (PENDING/SKIPPED) do not buzz.
+const REST_VIBRATION_SECONDS: Partial<Record<SessionSetStatus, number>> = {
+  COMPLETED: 120,
+  FAILED: 300,
+};
+
 @Injectable({
   providedIn: 'root',
 })
@@ -37,7 +44,7 @@ export class SessionPageFacade {
   private readonly debouncerService = inject(KeyedDebouncerService);
 
   readonly viewModel = signal<SessionPageViewModel>(initialState);
-  readonly timerResetTrigger = signal<number | null>(null);
+  readonly timerResetTrigger = signal<SessionTimerReset | null>(null);
 
   loadSessionData(sessionId: string | null): void {
     if (!sessionId) {
@@ -240,8 +247,21 @@ export class SessionPageFacade {
     );
   }
 
-  triggerTimerReset(disable: boolean = false): void {
-    this.timerResetTrigger.set(disable ? null : Date.now());
+  /**
+   * Restarts the rest timer for a set interaction. Passing the resulting set
+   * status schedules a buzz at the matching rest threshold; passing no status
+   * disables the timer (e.g. when leaving the session).
+   */
+  triggerTimerReset(status?: SessionSetStatus): void {
+    if (!status) {
+      this.timerResetTrigger.set(null);
+      return;
+    }
+
+    this.timerResetTrigger.set({
+      timestamp: Date.now(),
+      vibrateAfterSeconds: REST_VIBRATION_SECONDS[status] ?? null,
+    });
   }
 
   flushPendingSetUpdate(): void {

--- a/apps/web/src/app/features/sessions/shared/session-notification.service.spec.ts
+++ b/apps/web/src/app/features/sessions/shared/session-notification.service.spec.ts
@@ -3,7 +3,7 @@ import { SwPush } from '@angular/service-worker';
 import { Subject, of } from 'rxjs';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { PushService } from '@shared/api/push.service';
-import { SessionNotificationContent, SessionNotificationService } from './session-notification.service';
+import { SessionNotificationService } from './session-notification.service';
 
 vi.mock('../../../../environments/environment', () => ({
   environment: { vapidPublicKey: 'TEST_VAPID_KEY' },
@@ -11,30 +11,20 @@ vi.mock('../../../../environments/environment', () => ({
 
 interface NotificationClickEvent { action: string; notification: unknown; }
 
-const content: SessionNotificationContent = {
-  sessionId: 's1',
-  title: 'Push Day',
-  exerciseName: 'Bench Press',
-  reps: 5,
-  weight: 60,
-};
-
 describe('SessionNotificationService', () => {
   let clicks$: Subject<NotificationClickEvent>;
-  let showNotification: ReturnType<typeof vi.fn>;
   let getNotifications: ReturnType<typeof vi.fn>;
   let requestSubscription: ReturnType<typeof vi.fn>;
   let saveSubscription: ReturnType<typeof vi.fn>;
 
   const configure = (swEnabled: boolean, permission: NotificationPermission = 'granted') => {
     clicks$ = new Subject<NotificationClickEvent>();
-    showNotification = vi.fn().mockResolvedValue(undefined);
     getNotifications = vi.fn().mockResolvedValue([]);
     requestSubscription = vi.fn();
     saveSubscription = vi.fn().mockReturnValue(of({ data: null, error: null }));
 
     Object.defineProperty(navigator, 'serviceWorker', {
-      value: { ready: Promise.resolve({ showNotification, getNotifications }) },
+      value: { ready: Promise.resolve({ getNotifications }) },
       configurable: true,
     });
     vi.stubGlobal('Notification', {
@@ -54,7 +44,6 @@ describe('SessionNotificationService', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
-    vi.useRealTimers();
     TestBed.resetTestingModule();
   });
 
@@ -65,40 +54,9 @@ describe('SessionNotificationService', () => {
     it('reports unsupported and no-ops', async () => {
       expect(service.isSupported).toBe(false);
       await expect(service.requestPermission()).resolves.toBe('denied');
-      await expect(service.show(content)).resolves.toBeUndefined();
-      expect(showNotification).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('when supported and permission granted', () => {
-    let service: SessionNotificationService;
-    beforeEach(() => { service = configure(true, 'granted'); });
-    afterEach(async () => { await service.clear(); });
-
-    it('shows an ongoing notification with the current set and quick actions', async () => {
-      await service.show(content);
-
-      expect(showNotification).toHaveBeenCalledTimes(1);
-      const [title, options] = showNotification.mock.calls[0];
-      expect(title).toBe('Push Day');
-      expect(options.body).toBe('Bench Press · 60 kg · 5 reps');
-      expect(options.tag).toBe('session-active');
-      expect(options.requireInteraction).toBe(true);
-      expect(options.actions.map((a: { action: string }) => a.action)).toEqual(['complete-set', 'reset-timer']);
-      expect(options.data.onActionClick['complete-set'].url).toContain('action=complete-set');
-    });
-
-    it('omits weight from the body when absent', async () => {
-      await service.show({ ...content, weight: null });
-      expect(showNotification.mock.calls[0][1].body).toBe('Bench Press · 5 reps');
-    });
-
-    it('closes matching notifications on clear', async () => {
-      const close = vi.fn();
-      getNotifications.mockResolvedValue([{ close }]);
-      await service.clear();
-      expect(getNotifications).toHaveBeenCalledWith({ tag: 'session-active' });
-      expect(close).toHaveBeenCalled();
+      await expect(service.subscribeToPush()).resolves.toBeUndefined();
+      await expect(service.clear()).resolves.toBeUndefined();
+      expect(requestSubscription).not.toHaveBeenCalled();
     });
   });
 
@@ -115,18 +73,30 @@ describe('SessionNotificationService', () => {
 
       expect(requestSubscription).toHaveBeenCalledWith({ serverPublicKey: 'TEST_VAPID_KEY' });
       expect(saveSubscription).toHaveBeenCalledWith({ endpoint: 'https://push/1', keys: { p256dh: 'p', auth: 'a' } });
-      await service.clear();
     });
 
-    it('does nothing when the service worker is unsupported', async () => {
-      const service = configure(false, 'granted');
+    it('does nothing when permission is not granted', async () => {
+      const service = configure(true, 'default');
       await service.subscribeToPush();
       expect(requestSubscription).not.toHaveBeenCalled();
     });
   });
 
+  describe('clear', () => {
+    it('closes matching ongoing notifications', async () => {
+      const service = configure(true, 'granted');
+      const close = vi.fn();
+      getNotifications.mockResolvedValue([{ close }]);
+
+      await service.clear();
+
+      expect(getNotifications).toHaveBeenCalledWith({ tag: 'session-active' });
+      expect(close).toHaveBeenCalled();
+    });
+  });
+
   describe('actions$', () => {
-    it('emits only the two known quick actions', async () => {
+    it('emits only the two known quick actions', () => {
       const service = configure(true);
       const received: string[] = [];
       service.actions$.subscribe(a => received.push(a));
@@ -137,7 +107,6 @@ describe('SessionNotificationService', () => {
       clicks$.next({ action: 'reset-timer', notification: {} });
 
       expect(received).toEqual(['complete-set', 'reset-timer']);
-      await service.clear();
     });
   });
 });

--- a/apps/web/src/app/features/sessions/shared/session-notification.service.spec.ts
+++ b/apps/web/src/app/features/sessions/shared/session-notification.service.spec.ts
@@ -1,0 +1,110 @@
+import { TestBed } from '@angular/core/testing';
+import { SwPush } from '@angular/service-worker';
+import { Subject } from 'rxjs';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { SessionNotificationContent, SessionNotificationService } from './session-notification.service';
+
+interface NotificationClickEvent { action: string; notification: unknown; }
+
+const content: SessionNotificationContent = {
+  sessionId: 's1',
+  title: 'Push Day',
+  exerciseName: 'Bench Press',
+  reps: 5,
+  weight: 60,
+};
+
+describe('SessionNotificationService', () => {
+  let clicks$: Subject<NotificationClickEvent>;
+  let showNotification: ReturnType<typeof vi.fn>;
+  let getNotifications: ReturnType<typeof vi.fn>;
+
+  const configure = (swEnabled: boolean, permission: NotificationPermission = 'granted') => {
+    clicks$ = new Subject<NotificationClickEvent>();
+    showNotification = vi.fn().mockResolvedValue(undefined);
+    getNotifications = vi.fn().mockResolvedValue([]);
+
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: { ready: Promise.resolve({ showNotification, getNotifications }) },
+      configurable: true,
+    });
+    vi.stubGlobal('Notification', {
+      permission,
+      requestPermission: vi.fn().mockResolvedValue('granted'),
+    });
+
+    TestBed.configureTestingModule({
+      providers: [
+        SessionNotificationService,
+        { provide: SwPush, useValue: { isEnabled: swEnabled, notificationClicks: clicks$.asObservable() } },
+      ],
+    });
+    return TestBed.inject(SessionNotificationService);
+  };
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    TestBed.resetTestingModule();
+  });
+
+  describe('when the service worker is disabled', () => {
+    let service: SessionNotificationService;
+    beforeEach(() => { service = configure(false); });
+
+    it('reports unsupported and no-ops', async () => {
+      expect(service.isSupported).toBe(false);
+      await expect(service.requestPermission()).resolves.toBe('denied');
+      await expect(service.show(content)).resolves.toBeUndefined();
+      expect(showNotification).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when supported and permission granted', () => {
+    let service: SessionNotificationService;
+    beforeEach(() => { service = configure(true, 'granted'); });
+    afterEach(async () => { await service.clear(); });
+
+    it('shows an ongoing notification with the current set and quick actions', async () => {
+      await service.show(content);
+
+      expect(showNotification).toHaveBeenCalledTimes(1);
+      const [title, options] = showNotification.mock.calls[0];
+      expect(title).toBe('Push Day');
+      expect(options.body).toBe('Bench Press · 60 kg · 5 reps');
+      expect(options.tag).toBe('session-active');
+      expect(options.requireInteraction).toBe(true);
+      expect(options.actions.map((a: { action: string }) => a.action)).toEqual(['complete-set', 'reset-timer']);
+      expect(options.data.onActionClick['complete-set'].url).toContain('action=complete-set');
+    });
+
+    it('omits weight from the body when absent', async () => {
+      await service.show({ ...content, weight: null });
+      expect(showNotification.mock.calls[0][1].body).toBe('Bench Press · 5 reps');
+    });
+
+    it('closes matching notifications on clear', async () => {
+      const close = vi.fn();
+      getNotifications.mockResolvedValue([{ close }]);
+      await service.clear();
+      expect(getNotifications).toHaveBeenCalledWith({ tag: 'session-active' });
+      expect(close).toHaveBeenCalled();
+    });
+  });
+
+  describe('actions$', () => {
+    it('emits only the two known quick actions', async () => {
+      const service = configure(true);
+      const received: string[] = [];
+      service.actions$.subscribe(a => received.push(a));
+
+      clicks$.next({ action: '', notification: {} });
+      clicks$.next({ action: 'complete-set', notification: {} });
+      clicks$.next({ action: 'unknown', notification: {} });
+      clicks$.next({ action: 'reset-timer', notification: {} });
+
+      expect(received).toEqual(['complete-set', 'reset-timer']);
+      await service.clear();
+    });
+  });
+});

--- a/apps/web/src/app/features/sessions/shared/session-notification.service.spec.ts
+++ b/apps/web/src/app/features/sessions/shared/session-notification.service.spec.ts
@@ -1,8 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 import { SwPush } from '@angular/service-worker';
-import { Subject } from 'rxjs';
+import { Subject, of } from 'rxjs';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { PushService } from '@shared/api/push.service';
 import { SessionNotificationContent, SessionNotificationService } from './session-notification.service';
+
+vi.mock('../../../../environments/environment', () => ({
+  environment: { vapidPublicKey: 'TEST_VAPID_KEY' },
+}));
 
 interface NotificationClickEvent { action: string; notification: unknown; }
 
@@ -18,11 +23,15 @@ describe('SessionNotificationService', () => {
   let clicks$: Subject<NotificationClickEvent>;
   let showNotification: ReturnType<typeof vi.fn>;
   let getNotifications: ReturnType<typeof vi.fn>;
+  let requestSubscription: ReturnType<typeof vi.fn>;
+  let saveSubscription: ReturnType<typeof vi.fn>;
 
   const configure = (swEnabled: boolean, permission: NotificationPermission = 'granted') => {
     clicks$ = new Subject<NotificationClickEvent>();
     showNotification = vi.fn().mockResolvedValue(undefined);
     getNotifications = vi.fn().mockResolvedValue([]);
+    requestSubscription = vi.fn();
+    saveSubscription = vi.fn().mockReturnValue(of({ data: null, error: null }));
 
     Object.defineProperty(navigator, 'serviceWorker', {
       value: { ready: Promise.resolve({ showNotification, getNotifications }) },
@@ -36,7 +45,8 @@ describe('SessionNotificationService', () => {
     TestBed.configureTestingModule({
       providers: [
         SessionNotificationService,
-        { provide: SwPush, useValue: { isEnabled: swEnabled, notificationClicks: clicks$.asObservable() } },
+        { provide: SwPush, useValue: { isEnabled: swEnabled, notificationClicks: clicks$.asObservable(), requestSubscription } },
+        { provide: PushService, useValue: { saveSubscription } },
       ],
     });
     return TestBed.inject(SessionNotificationService);
@@ -89,6 +99,29 @@ describe('SessionNotificationService', () => {
       await service.clear();
       expect(getNotifications).toHaveBeenCalledWith({ tag: 'session-active' });
       expect(close).toHaveBeenCalled();
+    });
+  });
+
+  describe('subscribeToPush', () => {
+    it('requests a push subscription and registers it with the API', async () => {
+      const service = configure(true, 'granted');
+      const subscription = {
+        endpoint: 'https://push/1',
+        toJSON: () => ({ endpoint: 'https://push/1', keys: { p256dh: 'p', auth: 'a' } }),
+      } as unknown as PushSubscription;
+      requestSubscription.mockResolvedValue(subscription);
+
+      await service.subscribeToPush();
+
+      expect(requestSubscription).toHaveBeenCalledWith({ serverPublicKey: 'TEST_VAPID_KEY' });
+      expect(saveSubscription).toHaveBeenCalledWith({ endpoint: 'https://push/1', keys: { p256dh: 'p', auth: 'a' } });
+      await service.clear();
+    });
+
+    it('does nothing when the service worker is unsupported', async () => {
+      const service = configure(false, 'granted');
+      await service.subscribeToPush();
+      expect(requestSubscription).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/features/sessions/shared/session-notification.service.ts
+++ b/apps/web/src/app/features/sessions/shared/session-notification.service.ts
@@ -7,57 +7,23 @@ import { environment } from '../../../../environments/environment';
 
 export type SessionNotificationAction = 'complete-set' | 'reset-timer';
 
-export interface SessionNotificationContent {
-  sessionId: string;
-  title: string;
-  exerciseName: string;
-  reps: number;
-  weight?: number | null;
-}
-
-// Operations understood by Angular's ngsw `notificationclick` handler, read
-// from `notification.data.onActionClick[action]` to focus/open the app.
-type NgswClickOperation = 'openWindow' | 'focusLastFocusedOrOpen' | 'navigateLastFocusedOrOpen' | 'sendRequest';
-interface NgswActionClick {
-  operation: NgswClickOperation;
-  url: string;
-}
-
-// `actions`, `vibrate` and `renotify` are part of the Service Worker
-// notification spec but not always present on the DOM `NotificationOptions` type.
-interface NotificationActionButton {
-  action: string;
-  title: string;
-  icon?: string;
-}
-interface OngoingNotificationOptions extends NotificationOptions {
-  actions?: NotificationActionButton[];
-  vibrate?: number[];
-  renotify?: boolean;
-}
-
 const NOTIFICATION_TAG = 'session-active';
-const NOTIFICATION_ICON = '/assets/favicon/web-app-manifest-192x192.png';
-const REMINDER_INTERVAL_MS = 15 * 60 * 1000; // buzz every 15 min of inactivity
-const REMINDER_VIBRATION_PATTERN = [400, 150, 400];
 const ACTION_COMPLETE_SET: SessionNotificationAction = 'complete-set';
 const ACTION_RESET_TIMER: SessionNotificationAction = 'reset-timer';
 
 /**
- * Manages the OS-level ongoing notification shown while a workout session is
- * active: it displays the current set, offers quick actions, and periodically
- * re-alerts the user to keep logging so sessions are not left open.
+ * Client side of the session notification feature. The notifications themselves
+ * are delivered by the backend via Web Push (so they work while the app is
+ * backgrounded); this service registers the device's push subscription, exposes
+ * quick-action clicks, and closes the notification when a session ends.
  *
  * Everything degrades to a no-op when the service worker is disabled or the
- * Notification API is unavailable (e.g. local dev, unsupported browsers).
+ * Notification/Push APIs are unavailable (e.g. local dev, unsupported browsers).
  */
 @Injectable({ providedIn: 'root' })
 export class SessionNotificationService {
   private readonly swPush = inject(SwPush);
   private readonly pushService = inject(PushService);
-
-  private lastContent: SessionNotificationContent | null = null;
-  private reminderTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
   /** Emits when the user taps a quick action while the app is in the foreground. */
   readonly actions$: Observable<SessionNotificationAction> = this.swPush.notificationClicks.pipe(
@@ -106,38 +72,8 @@ export class SessionNotificationService {
     }
   }
 
-  private toCommand(subscription: PushSubscription): UpsertPushSubscriptionCommand {
-    const json = subscription.toJSON();
-    return {
-      endpoint: subscription.endpoint,
-      keys: {
-        p256dh: json.keys?.['p256dh'] ?? '',
-        auth: json.keys?.['auth'] ?? '',
-      },
-    };
-  }
-
-  /** Shows or refreshes the ongoing notification and (re)arms the inactivity reminder. */
-  async show(content: SessionNotificationContent): Promise<void> {
-    if (!this.isSupported) {
-      return;
-    }
-
-    this.lastContent = content;
-    // Only arm the inactivity reminder once the user has actually granted
-    // permission; otherwise the timer would fire against a notification that
-    // can never be shown.
-    if (Notification.permission === 'granted') {
-      this.restartReminder();
-    }
-    await this.render(content, { reAlert: false });
-  }
-
-  /** Clears the notification and stops the inactivity reminder. */
+  /** Closes the ongoing session notification (e.g. when a session ends). */
   async clear(): Promise<void> {
-    this.stopReminder();
-    this.lastContent = null;
-
     if (!this.isSupported) {
       return;
     }
@@ -147,64 +83,14 @@ export class SessionNotificationService {
     notifications.forEach(notification => notification.close());
   }
 
-  private async render(content: SessionNotificationContent, opts: { reAlert: boolean }): Promise<void> {
-    if (!this.isSupported || Notification.permission !== 'granted') {
-      return;
-    }
-
-    const registration = await navigator.serviceWorker.ready;
-    const options: OngoingNotificationOptions = {
-      tag: NOTIFICATION_TAG,
-      icon: NOTIFICATION_ICON,
-      body: this.buildBody(content),
-      requireInteraction: true,
-      silent: !opts.reAlert,
-      renotify: opts.reAlert,
-      vibrate: opts.reAlert ? REMINDER_VIBRATION_PATTERN : undefined,
-      actions: [
-        { action: ACTION_COMPLETE_SET, title: 'Complete set' },
-        { action: ACTION_RESET_TIMER, title: 'Stop timer' },
-      ],
-      data: { onActionClick: this.buildActionMap(content.sessionId) },
-    };
-
-    await registration.showNotification(content.title, options);
-  }
-
-  private buildBody(content: SessionNotificationContent): string {
-    const parts = [content.exerciseName];
-    if (content.weight != null) {
-      parts.push(`${content.weight} kg`);
-    }
-    parts.push(`${content.reps} reps`);
-    return parts.join(' · ');
-  }
-
-  private buildActionMap(sessionId: string): Record<string, NgswActionClick> {
-    const url = `/sessions/${sessionId}`;
+  private toCommand(subscription: PushSubscription): UpsertPushSubscriptionCommand {
+    const json = subscription.toJSON();
     return {
-      default: { operation: 'focusLastFocusedOrOpen', url },
-      [ACTION_COMPLETE_SET]: { operation: 'focusLastFocusedOrOpen', url: `${url}?action=${ACTION_COMPLETE_SET}` },
-      [ACTION_RESET_TIMER]: { operation: 'focusLastFocusedOrOpen', url: `${url}?action=${ACTION_RESET_TIMER}` },
+      endpoint: subscription.endpoint,
+      keys: {
+        p256dh: json.keys?.['p256dh'] ?? '',
+        auth: json.keys?.['auth'] ?? '',
+      },
     };
-  }
-
-  private restartReminder(): void {
-    this.stopReminder();
-    this.reminderTimeoutId = setTimeout(() => this.fireReminder(), REMINDER_INTERVAL_MS);
-  }
-
-  private stopReminder(): void {
-    if (this.reminderTimeoutId) {
-      clearTimeout(this.reminderTimeoutId);
-      this.reminderTimeoutId = null;
-    }
-  }
-
-  private async fireReminder(): Promise<void> {
-    if (this.lastContent) {
-      await this.render(this.lastContent, { reAlert: true });
-    }
-    this.restartReminder();
   }
 }

--- a/apps/web/src/app/features/sessions/shared/session-notification.service.ts
+++ b/apps/web/src/app/features/sessions/shared/session-notification.service.ts
@@ -1,0 +1,172 @@
+import { Injectable, inject } from '@angular/core';
+import { SwPush } from '@angular/service-worker';
+import { Observable, filter, map } from 'rxjs';
+
+export type SessionNotificationAction = 'complete-set' | 'reset-timer';
+
+export interface SessionNotificationContent {
+  sessionId: string;
+  title: string;
+  exerciseName: string;
+  reps: number;
+  weight?: number | null;
+}
+
+// Operations understood by Angular's ngsw `notificationclick` handler, read
+// from `notification.data.onActionClick[action]` to focus/open the app.
+type NgswClickOperation = 'openWindow' | 'focusLastFocusedOrOpen' | 'navigateLastFocusedOrOpen' | 'sendRequest';
+interface NgswActionClick {
+  operation: NgswClickOperation;
+  url: string;
+}
+
+// `actions`, `vibrate` and `renotify` are part of the Service Worker
+// notification spec but not always present on the DOM `NotificationOptions` type.
+interface NotificationActionButton {
+  action: string;
+  title: string;
+  icon?: string;
+}
+interface OngoingNotificationOptions extends NotificationOptions {
+  actions?: NotificationActionButton[];
+  vibrate?: number[];
+  renotify?: boolean;
+}
+
+const NOTIFICATION_TAG = 'session-active';
+const NOTIFICATION_ICON = '/assets/favicon/web-app-manifest-192x192.png';
+const REMINDER_INTERVAL_MS = 15 * 60 * 1000; // buzz every 15 min of inactivity
+const REMINDER_VIBRATION_PATTERN = [400, 150, 400];
+const ACTION_COMPLETE_SET: SessionNotificationAction = 'complete-set';
+const ACTION_RESET_TIMER: SessionNotificationAction = 'reset-timer';
+
+/**
+ * Manages the OS-level ongoing notification shown while a workout session is
+ * active: it displays the current set, offers quick actions, and periodically
+ * re-alerts the user to keep logging so sessions are not left open.
+ *
+ * Everything degrades to a no-op when the service worker is disabled or the
+ * Notification API is unavailable (e.g. local dev, unsupported browsers).
+ */
+@Injectable({ providedIn: 'root' })
+export class SessionNotificationService {
+  private readonly swPush = inject(SwPush);
+
+  private lastContent: SessionNotificationContent | null = null;
+  private reminderTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
+  /** Emits when the user taps a quick action while the app is in the foreground. */
+  readonly actions$: Observable<SessionNotificationAction> = this.swPush.notificationClicks.pipe(
+    map(event => event.action),
+    filter((action): action is SessionNotificationAction =>
+      action === ACTION_COMPLETE_SET || action === ACTION_RESET_TIMER),
+  );
+
+  get isSupported(): boolean {
+    return this.swPush.isEnabled
+      && typeof Notification !== 'undefined'
+      && typeof navigator !== 'undefined'
+      && !!navigator.serviceWorker;
+  }
+
+  /** Requests notification permission if not already decided. */
+  async requestPermission(): Promise<NotificationPermission> {
+    if (!this.isSupported) {
+      return 'denied';
+    }
+    if (Notification.permission !== 'default') {
+      return Notification.permission;
+    }
+    try {
+      return await Notification.requestPermission();
+    } catch {
+      return 'denied';
+    }
+  }
+
+  /** Shows or refreshes the ongoing notification and (re)arms the inactivity reminder. */
+  async show(content: SessionNotificationContent): Promise<void> {
+    if (!this.isSupported) {
+      return;
+    }
+
+    this.lastContent = content;
+    this.restartReminder();
+    await this.render(content, { reAlert: false });
+  }
+
+  /** Clears the notification and stops the inactivity reminder. */
+  async clear(): Promise<void> {
+    this.stopReminder();
+    this.lastContent = null;
+
+    if (!this.isSupported) {
+      return;
+    }
+
+    const registration = await navigator.serviceWorker.ready;
+    const notifications = await registration.getNotifications({ tag: NOTIFICATION_TAG });
+    notifications.forEach(notification => notification.close());
+  }
+
+  private async render(content: SessionNotificationContent, opts: { reAlert: boolean }): Promise<void> {
+    if (!this.isSupported || Notification.permission !== 'granted') {
+      return;
+    }
+
+    const registration = await navigator.serviceWorker.ready;
+    const options: OngoingNotificationOptions = {
+      tag: NOTIFICATION_TAG,
+      icon: NOTIFICATION_ICON,
+      body: this.buildBody(content),
+      requireInteraction: true,
+      silent: !opts.reAlert,
+      renotify: opts.reAlert,
+      vibrate: opts.reAlert ? REMINDER_VIBRATION_PATTERN : undefined,
+      actions: [
+        { action: ACTION_COMPLETE_SET, title: 'Complete set' },
+        { action: ACTION_RESET_TIMER, title: 'Stop timer' },
+      ],
+      data: { onActionClick: this.buildActionMap(content.sessionId) },
+    };
+
+    await registration.showNotification(content.title, options);
+  }
+
+  private buildBody(content: SessionNotificationContent): string {
+    const parts = [content.exerciseName];
+    if (content.weight != null) {
+      parts.push(`${content.weight} kg`);
+    }
+    parts.push(`${content.reps} reps`);
+    return parts.join(' · ');
+  }
+
+  private buildActionMap(sessionId: string): Record<string, NgswActionClick> {
+    const url = `/sessions/${sessionId}`;
+    return {
+      default: { operation: 'focusLastFocusedOrOpen', url },
+      [ACTION_COMPLETE_SET]: { operation: 'focusLastFocusedOrOpen', url: `${url}?action=${ACTION_COMPLETE_SET}` },
+      [ACTION_RESET_TIMER]: { operation: 'focusLastFocusedOrOpen', url: `${url}?action=${ACTION_RESET_TIMER}` },
+    };
+  }
+
+  private restartReminder(): void {
+    this.stopReminder();
+    this.reminderTimeoutId = setTimeout(() => this.fireReminder(), REMINDER_INTERVAL_MS);
+  }
+
+  private stopReminder(): void {
+    if (this.reminderTimeoutId) {
+      clearTimeout(this.reminderTimeoutId);
+      this.reminderTimeoutId = null;
+    }
+  }
+
+  private async fireReminder(): Promise<void> {
+    if (this.lastContent) {
+      await this.render(this.lastContent, { reAlert: true });
+    }
+    this.restartReminder();
+  }
+}

--- a/apps/web/src/app/features/sessions/shared/session-notification.service.ts
+++ b/apps/web/src/app/features/sessions/shared/session-notification.service.ts
@@ -1,6 +1,9 @@
 import { Injectable, inject } from '@angular/core';
 import { SwPush } from '@angular/service-worker';
-import { Observable, filter, map } from 'rxjs';
+import { Observable, filter, firstValueFrom, map } from 'rxjs';
+import { UpsertPushSubscriptionCommand } from '@txg/shared';
+import { PushService } from '@shared/api/push.service';
+import { environment } from '../../../../environments/environment';
 
 export type SessionNotificationAction = 'complete-set' | 'reset-timer';
 
@@ -51,6 +54,7 @@ const ACTION_RESET_TIMER: SessionNotificationAction = 'reset-timer';
 @Injectable({ providedIn: 'root' })
 export class SessionNotificationService {
   private readonly swPush = inject(SwPush);
+  private readonly pushService = inject(PushService);
 
   private lastContent: SessionNotificationContent | null = null;
   private reminderTimeoutId: ReturnType<typeof setTimeout> | null = null;
@@ -82,6 +86,35 @@ export class SessionNotificationService {
     } catch {
       return 'denied';
     }
+  }
+
+  /**
+   * Subscribes this device to Web Push and registers the subscription with the
+   * API so the backend can deliver rest/idle alerts. No-op when unsupported,
+   * unconfigured (no VAPID key), or permission is not granted.
+   */
+  async subscribeToPush(): Promise<void> {
+    if (!this.isSupported || !environment.vapidPublicKey || Notification.permission !== 'granted') {
+      return;
+    }
+
+    try {
+      const subscription = await this.swPush.requestSubscription({ serverPublicKey: environment.vapidPublicKey });
+      await firstValueFrom(this.pushService.saveSubscription(this.toCommand(subscription)));
+    } catch (e) {
+      console.error('Failed to subscribe to push notifications', e);
+    }
+  }
+
+  private toCommand(subscription: PushSubscription): UpsertPushSubscriptionCommand {
+    const json = subscription.toJSON();
+    return {
+      endpoint: subscription.endpoint,
+      keys: {
+        p256dh: json.keys?.['p256dh'] ?? '',
+        auth: json.keys?.['auth'] ?? '',
+      },
+    };
   }
 
   /** Shows or refreshes the ongoing notification and (re)arms the inactivity reminder. */

--- a/apps/web/src/app/features/sessions/shared/session-notification.service.ts
+++ b/apps/web/src/app/features/sessions/shared/session-notification.service.ts
@@ -91,7 +91,12 @@ export class SessionNotificationService {
     }
 
     this.lastContent = content;
-    this.restartReminder();
+    // Only arm the inactivity reminder once the user has actually granted
+    // permission; otherwise the timer would fire against a notification that
+    // can never be shown.
+    if (Notification.permission === 'granted') {
+      this.restartReminder();
+    }
     await this.render(content, { reAlert: false });
   }
 

--- a/apps/web/src/app/shared/api/push.service.ts
+++ b/apps/web/src/app/shared/api/push.service.ts
@@ -1,0 +1,25 @@
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { PushSubscriptionDto, UpsertPushSubscriptionCommand } from '@txg/shared';
+import { ApiService, ApiServiceResponse } from './api.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PushService {
+  private apiService = inject(ApiService);
+
+  /**
+   * Registers (or refreshes) a Web Push subscription for the current user.
+   */
+  saveSubscription(command: UpsertPushSubscriptionCommand): Observable<ApiServiceResponse<PushSubscriptionDto>> {
+    return this.apiService.post<UpsertPushSubscriptionCommand, PushSubscriptionDto>('/push/subscriptions', command);
+  }
+
+  /**
+   * Removes a Web Push subscription for the current user by its endpoint.
+   */
+  deleteSubscription(endpoint: string): Observable<ApiServiceResponse<null>> {
+    return this.apiService.delete(`/push/subscriptions?endpoint=${encodeURIComponent(endpoint)}`);
+  }
+}

--- a/apps/web/src/environments/environment.ts
+++ b/apps/web/src/environments/environment.ts
@@ -12,5 +12,6 @@ export const environment = {
   supabase: {
     url: '__SUPABASE_URL__',
     key: '__SUPABASE_PUBLISHABLE_KEY__',
-  }
+  },
+  vapidPublicKey: '__VAPID_PUBLIC_KEY__',
 };

--- a/packages/shared/src/api.types.ts
+++ b/packages/shared/src/api.types.ts
@@ -179,3 +179,15 @@ export type FailSessionSetCommand = Record<string, never>; // Represents an empt
 // For PATCH /sessions/{sessionId}/sets/{setId}/reset
 // Request body is empty.
 export type ResetSessionSetCommand = Record<string, never>; // Represents an empty request body
+
+// 10. Push Subscription DTO and Command
+export type PushSubscriptionDto = Database["public"]["Tables"]["push_subscriptions"]["Row"];
+
+// Mirrors the browser `PushSubscription.toJSON()` shape sent when registering a device.
+export type UpsertPushSubscriptionCommand = {
+  endpoint: string;
+  keys: {
+    p256dh: string;
+    auth: string;
+  };
+};

--- a/packages/shared/src/database.types.ts
+++ b/packages/shared/src/database.types.ts
@@ -257,6 +257,33 @@ export interface Database {
           },
         ]
       }
+      push_subscriptions: {
+        Row: {
+          auth: string
+          created_at: string
+          endpoint: string
+          id: string
+          p256dh: string
+          user_id: string
+        }
+        Insert: {
+          auth: string
+          created_at?: string
+          endpoint: string
+          id?: string
+          p256dh: string
+          user_id: string
+        }
+        Update: {
+          auth?: string
+          created_at?: string
+          endpoint?: string
+          id?: string
+          p256dh?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
       session_sets: {
         Row: {
           actual_reps: number | null

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ importers:
       '@azure/functions':
         specifier: ^4.7.0
         version: 4.16.1
+      '@azure/storage-queue':
+        specifier: ^12.31.0
+        version: 12.31.0
       '@marplex/hono-azurefunc-adapter':
         specifier: ^1.0.1
         version: 1.0.1
@@ -61,6 +64,9 @@ importers:
       hono:
         specifier: ^4.7.0
         version: 4.12.27
+      web-push:
+        specifier: ^3.6.7
+        version: 3.6.7
       zod:
         specifier: ^3.24.3
         version: 3.25.76
@@ -68,6 +74,9 @@ importers:
       '@types/node':
         specifier: ^24.0.0
         version: 24.13.2
+      '@types/web-push':
+        specifier: ^3.6.4
+        version: 3.6.4
       '@vitest/coverage-v8':
         specifier: ^3.2.2
         version: 3.2.6(supports-color@8.1.1)(vitest@3.2.6)
@@ -593,6 +602,45 @@ packages:
       '@angular/core': 22.0.5
       rxjs: ^6.5.3 || ^7.4.0
 
+  '@azure/abort-controller@2.1.2':
+    resolution: {integrity: sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/core-auth@1.10.1':
+    resolution: {integrity: sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/core-client@1.10.2':
+    resolution: {integrity: sha512-1D2LpsU7y9xrqKjdIbsB7PlrRePw0xsVV8p+AKTlzITrWmscajryfJCdDJB/oGwvDI5HmRo04eMMADB67uwAwQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/core-http-compat@2.4.0':
+    resolution: {integrity: sha512-f1P96IB399YiN2ARYHP7EpZi3Bf3wH4SN2lGzrw7JVwm7bbsVYtf2iKSBwTywD2P62NOPZGHFSZi+6jjb75JuA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@azure/core-client': ^1.10.0
+      '@azure/core-rest-pipeline': ^1.22.0
+
+  '@azure/core-paging@1.6.2':
+    resolution: {integrity: sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/core-rest-pipeline@1.24.0':
+    resolution: {integrity: sha512-PpLsoDQ3AMmKZ0VU+0GrmqMxgp/sExjlVm4R+nLWngeoEGAzOIPVifaxKGU5gMv+nWELUoHfvrolWD+ZS/nFJg==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/core-tracing@1.3.1':
+    resolution: {integrity: sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/core-util@1.13.1':
+    resolution: {integrity: sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/core-xml@1.5.1':
+    resolution: {integrity: sha512-xcNRHqCoSp4AunOALEae6A8f3qATb83gSrm31Iqb01OzblvC3/W/bfXozcq78EzIdzZzuH1bZ2NvRR0TdX709w==}
+    engines: {node: '>=20.0.0'}
+
   '@azure/functions-extensions-base@0.3.0':
     resolution: {integrity: sha512-Cux0hLu5ZXlC/Kb+yvJVhRLIdkfFwui2HeT5oGZL00r/GCUUkhGTzRfZUjRN4Bq729mPv3okPucz2z7SMQLStA==}
     engines: {node: '>=18.0'}
@@ -600,6 +648,18 @@ packages:
   '@azure/functions@4.16.1':
     resolution: {integrity: sha512-A9obwC7IBg4NAmxUfTVfYEd8Xg6Px+o85JRprS3UJZt+GYYzIOmEecnFwTe3rl+aiHDewBk/8fnIVrSjR/fNGQ==}
     engines: {node: '>=20.0'}
+
+  '@azure/logger@1.3.0':
+    resolution: {integrity: sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/storage-common@12.4.1':
+    resolution: {integrity: sha512-t14unw/WofGDUi7TKJrsyXyPsN+NLgRm7hMaq0llxNmTIzt7f257+6LE6FKIJPh88zLj6M7LPvzve0fEYg/L3A==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/storage-queue@12.31.0':
+    resolution: {integrity: sha512-OzhvKO7G8+EXkUQPbKFkO7JNIAMkQZ9gMyZ85dsTCOk8jRRCbGbn3wsk3qrCAf6XWm+E2/fUsdLbX4YCOAWEKw==}
+    engines: {node: '>=22.0.0'}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -2132,6 +2192,9 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@nodable/entities@2.2.0':
+    resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -3098,6 +3161,9 @@ packages:
   '@types/tmp@0.2.6':
     resolution: {integrity: sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==}
 
+  '@types/web-push@3.6.4':
+    resolution: {integrity: sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -3209,6 +3275,10 @@ packages:
   '@typescript-eslint/visitor-keys@8.62.1':
     resolution: {integrity: sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typespec/ts-http-runtime@0.3.6':
+    resolution: {integrity: sha512-jIXhD0eWQ1JA6ln/5Dltyx22UxWNrw0hZmhy2rlv6m6KgF7kplHx3g0fzi09lNmTJQRR91OlemYp3xFnvDK9og==}
+    engines: {node: '>=20.0.0'}
 
   '@ungap/structured-clone@1.3.2':
     resolution: {integrity: sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==}
@@ -3560,6 +3630,9 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  anynum@1.0.1:
+    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
+
   arch@2.2.0:
     resolution: {integrity: sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==}
 
@@ -3600,6 +3673,9 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
+
+  asn1.js@5.4.1:
+    resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
 
   asn1@0.2.6:
     resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
@@ -3735,6 +3811,9 @@ packages:
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
+  bn.js@4.12.4:
+    resolution: {integrity: sha512-njR1b+ixG2ufvL9Zn9JGneW+b5GV6jqpYyPPpg4QVt723b5kJPGUczkUyWEH9BwEA74UakJZ43I4FDLBF7ci0g==}
+
   body-parser@1.20.5:
     resolution: {integrity: sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -3770,6 +3849,9 @@ packages:
 
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -4203,6 +4285,9 @@ packages:
   ecc-jsbn@0.1.2:
     resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
 
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
   eciesjs@0.5.0:
     resolution: {integrity: sha512-s0J9SEVYAEPg7J63GFMApLYzPH9VNIQIyC6s15JpnqVc0TqcKWdbgFlnAweEBRyMmko2dcs2sfC83Hj4J43tuA==}
     engines: {bun: '>=1', deno: '>=2.7.10', node: '>=16'}
@@ -4562,6 +4647,13 @@ packages:
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
+  fast-xml-builder@1.2.1:
+    resolution: {integrity: sha512-tPb5TTWfgfVx5BNSi2xV0eLr89POeXXn0dXIsCJ9m1narrWxeIyx6je9d7Rce/3NyXLbvuQmLkxq+RuxMWejvw==}
+
+  fast-xml-parser@5.9.3:
+    resolution: {integrity: sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==}
+    hasBin: true
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -4898,6 +4990,10 @@ packages:
     resolution: {integrity: sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==}
     engines: {node: '>=0.10'}
 
+  http_ece@1.2.0:
+    resolution: {integrity: sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==}
+    engines: {node: '>=16'}
+
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
@@ -5192,6 +5288,9 @@ packages:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
 
+  is-unsafe@1.0.1:
+    resolution: {integrity: sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==}
+
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
     engines: {node: '>= 0.4'}
@@ -5346,6 +5445,12 @@ packages:
   jsprim@2.0.2:
     resolution: {integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==}
     engines: {'0': node >=0.6.0}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   karma-source-map-support@1.4.0:
     resolution: {integrity: sha512-RsBECncGO17KAoJCYXjv+ckIz+Ii9NCi+9enk+rq6XC81ezYkb4/RHE6CTXdA7IOJqoF3wcaLfVG0CPmE5ca6A==}
@@ -5977,6 +6082,10 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
+
+  path-expression-matcher@1.6.1:
+    resolution: {integrity: sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==}
+    engines: {node: '>=14.0.0'}
 
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -6824,6 +6933,9 @@ packages:
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
+  strnum@2.4.1:
+    resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
+
   stylus@0.64.0:
     resolution: {integrity: sha512-ZIdT8eUv8tegmqy1tTIdJv9We2DumkNZFdCF5mz/Kpq3OcTaxSuCAYZge6HKK2CmNC02G1eJig2RV7XTw5hQrA==}
     engines: {node: '>=16'}
@@ -7348,6 +7460,11 @@ packages:
   weak-lru-cache@1.2.2:
     resolution: {integrity: sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==}
 
+  web-push@3.6.7:
+    resolution: {integrity: sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==}
+    engines: {node: '>= 16'}
+    hasBin: true
+
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -7512,6 +7629,10 @@ packages:
   xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
     engines: {node: '>=12'}
+
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
@@ -8122,12 +8243,114 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
 
+  '@azure/abort-controller@2.1.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@azure/core-auth@1.10.1':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-util': 1.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-client@1.10.2':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-rest-pipeline': 1.24.0
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-http-compat@2.4.0(@azure/core-client@1.10.2)(@azure/core-rest-pipeline@1.24.0)':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-client': 1.10.2
+      '@azure/core-rest-pipeline': 1.24.0
+
+  '@azure/core-paging@1.6.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@azure/core-rest-pipeline@1.24.0':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      '@typespec/ts-http-runtime': 0.3.6
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-tracing@1.3.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@azure/core-util@1.13.1':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@typespec/ts-http-runtime': 0.3.6
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-xml@1.5.1':
+    dependencies:
+      fast-xml-parser: 5.9.3
+      tslib: 2.8.1
+
   '@azure/functions-extensions-base@0.3.0': {}
 
   '@azure/functions@4.16.1':
     dependencies:
       '@azure/functions-extensions-base': 0.3.0
       cookie: 0.7.2
+
+  '@azure/logger@1.3.0':
+    dependencies:
+      '@typespec/ts-http-runtime': 0.3.6
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/storage-common@12.4.1(@azure/core-client@1.10.2)':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-http-compat': 2.4.0(@azure/core-client@1.10.2)(@azure/core-rest-pipeline@1.24.0)
+      '@azure/core-rest-pipeline': 1.24.0
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      events: 3.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@azure/core-client'
+      - supports-color
+
+  '@azure/storage-queue@12.31.0':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-client': 1.10.2
+      '@azure/core-http-compat': 2.4.0(@azure/core-client@1.10.2)(@azure/core-rest-pipeline@1.24.0)
+      '@azure/core-paging': 1.6.2
+      '@azure/core-rest-pipeline': 1.24.0
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/core-xml': 1.5.1
+      '@azure/logger': 1.3.0
+      '@azure/storage-common': 12.4.1(@azure/core-client@1.10.2)
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -9691,6 +9914,8 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
+  '@nodable/entities@2.2.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -10501,6 +10726,10 @@ snapshots:
 
   '@types/tmp@0.2.6': {}
 
+  '@types/web-push@3.6.4':
+    dependencies:
+      '@types/node': 24.13.2
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 24.13.2
@@ -10728,6 +10957,14 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.62.1
       eslint-visitor-keys: 5.0.1
+
+  '@typespec/ts-http-runtime@0.3.6':
+    dependencies:
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@ungap/structured-clone@1.3.2': {}
 
@@ -11119,6 +11356,8 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
+  anynum@1.0.1: {}
+
   arch@2.2.0: {}
 
   argparse@2.0.1: {}
@@ -11178,6 +11417,13 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
+
+  asn1.js@5.4.1:
+    dependencies:
+      bn.js: 4.12.4
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      safer-buffer: 2.1.2
 
   asn1@0.2.6:
     dependencies:
@@ -11317,6 +11563,8 @@ snapshots:
 
   bluebird@3.7.2: {}
 
+  bn.js@4.12.4: {}
+
   body-parser@1.20.5:
     dependencies:
       bytes: 3.1.2
@@ -11381,6 +11629,8 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.4)
 
   buffer-crc32@0.2.13: {}
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -11836,6 +12086,10 @@ snapshots:
     dependencies:
       jsbn: 0.1.1
       safer-buffer: 2.1.2
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   eciesjs@0.5.0:
     dependencies:
@@ -12472,6 +12726,20 @@ snapshots:
     dependencies:
       fast-string-width: 3.0.2
 
+  fast-xml-builder@1.2.1:
+    dependencies:
+      path-expression-matcher: 1.6.1
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.9.3:
+    dependencies:
+      '@nodable/entities': 2.2.0
+      fast-xml-builder: 1.2.1
+      is-unsafe: 1.0.1
+      path-expression-matcher: 1.6.1
+      strnum: 2.4.1
+      xml-naming: 0.1.0
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -12865,6 +13133,8 @@ snapshots:
       jsprim: 2.0.2
       sshpk: 1.18.0
 
+  http_ece@1.2.0: {}
+
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
@@ -13117,6 +13387,8 @@ snapshots:
 
   is-unicode-supported@2.1.0: {}
 
+  is-unsafe@1.0.1: {}
+
   is-weakmap@2.0.2: {}
 
   is-weakref@1.1.1:
@@ -13277,6 +13549,17 @@ snapshots:
       extsprintf: 1.3.0
       json-schema: 0.4.0
       verror: 1.10.0
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   karma-source-map-support@1.4.0:
     dependencies:
@@ -14003,6 +14286,8 @@ snapshots:
   path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
+
+  path-expression-matcher@1.6.1: {}
 
   path-is-absolute@1.0.1: {}
 
@@ -14936,6 +15221,10 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
+  strnum@2.4.1:
+    dependencies:
+      anynum: 1.0.1
+
   stylus@0.64.0:
     dependencies:
       '@adobe/css-tools': 4.3.3
@@ -15562,6 +15851,16 @@ snapshots:
   weak-lru-cache@1.2.2:
     optional: true
 
+  web-push@3.6.7:
+    dependencies:
+      asn1.js: 5.4.1
+      http_ece: 1.2.0
+      https-proxy-agent: 7.0.6
+      jws: 4.0.1
+      minimist: 1.2.8
+    transitivePeerDependencies:
+      - supports-color
+
   webidl-conversions@7.0.0: {}
 
   webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.106.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.16)):
@@ -15796,6 +16095,8 @@ snapshots:
       powershell-utils: 0.1.0
 
   xml-name-validator@4.0.0: {}
+
+  xml-naming@0.1.0: {}
 
   xmlchars@2.2.0: {}
 

--- a/supabase/migrations/20260705210613_add_push_subscriptions.sql
+++ b/supabase/migrations/20260705210613_add_push_subscriptions.sql
@@ -1,0 +1,56 @@
+-- Migration: Add push_subscriptions table
+-- Description: Stores Web Push subscriptions so the backend can deliver
+--              session rest/idle notifications to a user's devices.
+-- Affected tables: public.push_subscriptions (new)
+-- Special considerations: One row per browser push endpoint. The background
+--   push sender reads this table with the service-role key (bypassing RLS);
+--   authenticated users may only manage their own subscriptions.
+-- Author: Claude
+-- Created: 2026-07-05
+
+-- -----------------------------------------------------
+-- Table push_subscriptions
+-- -----------------------------------------------------
+create table "public"."push_subscriptions" (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid not null,
+    endpoint text not null unique,
+    p256dh text not null,
+    auth text not null,
+    created_at timestamptz not null default now(),
+    foreign key (user_id) references auth.users(id) on delete cascade
+);
+
+comment on table "public"."push_subscriptions" is 'Web Push subscriptions used to deliver session notifications to user devices.';
+
+-- Index for looking up all of a user's subscriptions when sending a push.
+create index push_subscriptions_user_id_idx on public.push_subscriptions(user_id);
+
+-- Enable RLS: this table holds per-user device tokens and must be protected.
+alter table "public"."push_subscriptions" enable row level security;
+
+-- RLS Policy for anon role (no access): subscriptions are private to a user.
+create policy "push_subscriptions_anon_no_access" on "public"."push_subscriptions"
+    for all to anon
+    using (false);
+
+-- RLS Policy: a user may read only their own subscriptions.
+create policy "push_subscriptions_authenticated_select" on "public"."push_subscriptions"
+    for select to authenticated
+    using (user_id = auth.uid());
+
+-- RLS Policy: a user may register a subscription only for themselves.
+create policy "push_subscriptions_authenticated_insert" on "public"."push_subscriptions"
+    for insert to authenticated
+    with check (user_id = auth.uid());
+
+-- RLS Policy: a user may update only their own subscriptions (e.g. re-key an endpoint).
+create policy "push_subscriptions_authenticated_update" on "public"."push_subscriptions"
+    for update to authenticated
+    using (user_id = auth.uid())
+    with check (user_id = auth.uid());
+
+-- RLS Policy: a user may delete only their own subscriptions (e.g. on unsubscribe).
+create policy "push_subscriptions_authenticated_delete" on "public"."push_subscriptions"
+    for delete to authenticated
+    using (user_id = auth.uid());


### PR DESCRIPTION
## Summary

Implements #40 — session rest alerts that reach the user **even when the app is backgrounded or closed**, via backend **Web Push**.

On-device testing showed the original client-driven notification couldn't work: mobile browsers freeze background JavaScript (so an in-page timer/vibration stops when you leave the app) and web notifications can't live-tick. So the alert now originates from the server: when a set is completed/failed, the API schedules a delayed push (Azure Storage Queue visibility timeout) that a queue-triggered function delivers — a "Rest over" buzz after the rest window (2 min completed / 5 min failed) and a 15-minute idle reminder. Stale alerts are skipped by re-checking session state at delivery.

## What's included

**Service worker / infra**
- Fix: staging build now emits `ngsw-worker.js` (`angular.json`), so the SW actually registers on staging (it silently failed before).

**Client (`@txg/web`)**
- Foreground rest-timer vibration (2/5 min) + quick-action handling (`SwPush.notificationClicks` warm path, `?action=` cold-start path) + `selectCurrentSet`.
- `SessionNotificationService` registers the device's push subscription on permission grant, exposes quick actions, and closes the notification on session end. VAPID public key threaded through env + CD.

**API (`@txg/api`)**
- `push_subscriptions` table + RLS; `POST` / `DELETE /api/push/subscriptions`.
- `sendPush` storage-queue trigger delivering via `web-push`, using a background-only service-role Supabase client; prunes stale (404/410) endpoints.
- Rest/reminder alerts scheduled on set complete/fail with delivery-time validation.

## Prerequisites to deploy/test (you provision)

- Generate VAPID keys: `npx web-push generate-vapid-keys`.
- Add to GitHub secrets + Azure app settings (staging/prod): `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT`, `SUPABASE_SECRET_KEY`; add repo **variable** `VAPID_PUBLIC_KEY`. Locally, set these in `apps/api/local.settings.json` and `apps/web/src/environments/environment.development.ts` (`vapidPublicKey`).
- The migration runs via the existing DB CD step.

## Verification

- Green: `pnpm -r lint`, **230 web** + **49 api** unit tests, web build, api esbuild bundle, api typecheck.
- Not verifiable from CI (needs a device + provisioned keys): install the PWA on Android from staging, start a session, complete a set, background the app → "Rest over" buzz after ~2 min; verify the 15-min reminder, quick actions, and that logging the next set early suppresses the stale alert.

## Notes

- MVP delivers rest-over + idle-reminder alerts; it intentionally does not push a per-set "ongoing" refresh (a live-ticking notification isn't possible on the web).
- Introduces the Supabase secret key scoped strictly to the background sender; request handlers still use publishable key + user JWT.

Closes #40
