### PR TITLE
feat(progress): Improve chart interactions and series ordering

### DIFF
--- a/apps/web/src/app/features/progress/models/progress.mapping.spec.ts
+++ b/apps/web/src/app/features/progress/models/progress.mapping.spec.ts
@@ -108,3 +108,71 @@ describe('mapToExerciseSeriesViewModels', () => {
     expect(result[0].points[0].planName).toBe('Unknown plan');
   });
 });
+
+describe('mapToExerciseSeriesViewModels ordering', () => {
+  function makePlan(id: string, createdAt: string, dayExerciseIds: string[][]): PlanDto {
+    return {
+      id,
+      name: `Plan ${id}`,
+      created_at: createdAt,
+      days: dayExerciseIds.map((exerciseIds, dayIndex) => ({
+        id: `${id}-day-${dayIndex}`,
+        order_index: dayIndex,
+        exercises: exerciseIds.map((exerciseId, exerciseIndex) => ({
+          id: `${id}-day-${dayIndex}-ex-${exerciseIndex}`,
+          exercise_id: exerciseId,
+          order_index: exerciseIndex,
+        })),
+      })),
+    } as PlanDto;
+  }
+
+  // Alphabetical input order, as the API returns it.
+  const DTOS = [
+    makeDto({ exercise_id: 'ex-bench', exercise_name: 'Bench Press' }),
+    makeDto({ exercise_id: 'ex-deadlift', exercise_name: 'Deadlift' }),
+    makeDto({ exercise_id: 'ex-squat', exercise_name: 'Squat' }),
+  ];
+
+  it('should order series by exercise appearance in the plan', () => {
+    const plan = makePlan('plan-1', '2026-01-01T00:00:00.000Z', [['ex-squat', 'ex-bench'], ['ex-deadlift']]);
+
+    const result = mapToExerciseSeriesViewModels(DTOS, [plan], () => true);
+
+    expect(result.map(s => s.exerciseId)).toEqual(['ex-squat', 'ex-bench', 'ex-deadlift']);
+  });
+
+  it('should rank exercises of an older plan before those of a newer one', () => {
+    const newer = makePlan('plan-newer', '2026-05-01T00:00:00.000Z', [['ex-deadlift', 'ex-squat']]);
+    const older = makePlan('plan-older', '2026-01-01T00:00:00.000Z', [['ex-squat', 'ex-bench']]);
+
+    const result = mapToExerciseSeriesViewModels(DTOS, [newer, older], () => true);
+
+    expect(result.map(s => s.exerciseId)).toEqual(['ex-squat', 'ex-bench', 'ex-deadlift']);
+  });
+
+  it('should keep exercises absent from every plan last, in API order', () => {
+    const plan = makePlan('plan-1', '2026-01-01T00:00:00.000Z', [['ex-squat']]);
+
+    const result = mapToExerciseSeriesViewModels(DTOS, [plan], () => true);
+
+    expect(result.map(s => s.exerciseId)).toEqual(['ex-squat', 'ex-bench', 'ex-deadlift']);
+  });
+
+  it('should scope the appearance order to the selected plan when one is set', () => {
+    const older = makePlan('plan-older', '2026-01-01T00:00:00.000Z', [['ex-squat', 'ex-bench']]);
+    const newer = makePlan('plan-newer', '2026-05-01T00:00:00.000Z', [['ex-deadlift', 'ex-squat']]);
+
+    const result = mapToExerciseSeriesViewModels(DTOS, [older, newer], () => true, 'plan-newer');
+
+    expect(result.map(s => s.exerciseId)).toEqual(['ex-deadlift', 'ex-squat', 'ex-bench']);
+  });
+
+  it('should assign color tokens by the sorted position', () => {
+    const plan = makePlan('plan-1', '2026-01-01T00:00:00.000Z', [['ex-squat', 'ex-bench'], ['ex-deadlift']]);
+
+    const result = mapToExerciseSeriesViewModels(DTOS, [plan], () => true);
+
+    expect(result.map(s => s.colorToken)).toEqual([SERIES_COLOR_TOKENS[0], SERIES_COLOR_TOKENS[1], SERIES_COLOR_TOKENS[2]]);
+  });
+});

--- a/apps/web/src/app/features/progress/models/progress.mapping.ts
+++ b/apps/web/src/app/features/progress/models/progress.mapping.ts
@@ -53,24 +53,53 @@ export function formatRepsLabel(reps: number[]): string {
 }
 
 /**
- * Maps aggregated progress DTOs to chart series view models.
- *
- * Color tokens are assigned by series position (the API returns series sorted by
- * exercise name), so they stay stable while toggling visibility. Plan names
- * are resolved per point for the tooltip; selection is decided by the caller.
+ * Ranks exercises by their first appearance in the given plans
+ * (plans oldest to newest, then day and exercise order).
+ */
+function buildPlanAppearanceRank(plans: PlanDto[]): Map<string, number> {
+  const rank = new Map<string, number>();
+  const plansOldestFirst = [...plans].sort((a, b) => (a.created_at ?? '').localeCompare(b.created_at ?? ''));
+
+  for (const plan of plansOldestFirst) {
+    const days = [...(plan.days ?? [])].sort((a, b) => a.order_index - b.order_index);
+    for (const day of days) {
+      const exercises = [...(day.exercises ?? [])].sort((a, b) => a.order_index - b.order_index);
+      for (const exercise of exercises) {
+        if (!rank.has(exercise.exercise_id)) {
+          rank.set(exercise.exercise_id, rank.size);
+        }
+      }
+    }
+  }
+
+  return rank;
+}
+
+/**
+ * Maps aggregated progress DTOs to chart series view models, ordered by exercise
+ * appearance in the plans; exercises in no plan keep the API's alphabetical order,
+ * last. Color tokens are assigned by series position, so they stay stable while
+ * toggling visibility.
  *
  * @param dtos Aggregated series from the API.
- * @param plans All user plans, used to resolve plan names.
+ * @param plans All user plans, used to resolve plan names and appearance order.
  * @param isSelected Predicate deciding the initial selection of each series.
+ * @param selectedPlanId When set, only that plan defines the appearance order.
  */
 export function mapToExerciseSeriesViewModels(
   dtos: ExerciseProgressDto[],
   plans: PlanDto[],
-  isSelected: (exerciseId: string) => boolean
+  isSelected: (exerciseId: string) => boolean,
+  selectedPlanId: string | null = null
 ): ExerciseSeriesViewModel[] {
   const planNames = new Map(plans.map(p => [p.id, p.name]));
+  const rankSource = selectedPlanId ? plans.filter(p => p.id === selectedPlanId) : plans;
+  const appearanceRank = buildPlanAppearanceRank(rankSource);
+  const rankOf = (exerciseId: string) => appearanceRank.get(exerciseId) ?? Number.MAX_SAFE_INTEGER;
 
-  return dtos.map((dto, index) => ({
+  const sortedDtos = [...dtos].sort((a, b) => rankOf(a.exercise_id) - rankOf(b.exercise_id));
+
+  return sortedDtos.map((dto, index) => ({
     exerciseId: dto.exercise_id,
     exerciseName: dto.exercise_name,
     colorToken: SERIES_COLOR_TOKENS[index % SERIES_COLOR_TOKENS.length],

--- a/apps/web/src/app/features/progress/pages/progress-page/components/exercise-chip-row/exercise-chip-row.component.html
+++ b/apps/web/src/app/features/progress/pages/progress-page/components/exercise-chip-row/exercise-chip-row.component.html
@@ -1,4 +1,4 @@
-<div txgAutoHideScrollbar class="overflow-x-auto">
+<div txgAutoHideScrollbar class="overflow-x-auto pb-2">
   <mat-chip-listbox multiple aria-label="Plotted exercises">
     @for (exercise of exercises; track exercise.exerciseId) {
       <mat-chip-option

--- a/apps/web/src/app/features/progress/pages/progress-page/components/progress-chart/progress-chart.component.html
+++ b/apps/web/src/app/features/progress/pages/progress-page/components/progress-chart/progress-chart.component.html
@@ -4,6 +4,7 @@
     type="line"
     [data]="chartData"
     [options]="chartOptions"
+    [plugins]="chartPlugins"
     [legend]="false"
     data-cy="progress-chart-canvas">
   </canvas>

--- a/apps/web/src/app/features/progress/pages/progress-page/components/progress-chart/progress-chart.component.ts
+++ b/apps/web/src/app/features/progress/pages/progress-page/components/progress-chart/progress-chart.component.ts
@@ -33,12 +33,13 @@ const dayXInteractionMode: InteractionModeFunction = (chart, event, options, use
     return nearest;
   }
 
-  // Points are normalized to day precision, so points of one day share their pixel x.
-  const targetX = nearest[0].element.x;
+  const dayOf = (datasetIndex: number, index: number) => (chart.data.datasets[datasetIndex].data[index] as { x: number }).x;
+
+  const targetDay = dayOf(nearest[0].datasetIndex, nearest[0].index);
   const items: InteractionItem[] = [];
   for (const meta of chart.getSortedVisibleDatasetMetas()) {
     meta.data.forEach((element, index) => {
-      if (Math.abs(element.x - targetX) < 1) {
+      if (dayOf(meta.index, index) === targetDay) {
         items.push({ element, datasetIndex: meta.index, index });
       }
     });

--- a/apps/web/src/app/features/progress/pages/progress-page/components/progress-chart/progress-chart.component.ts
+++ b/apps/web/src/app/features/progress/pages/progress-page/components/progress-chart/progress-chart.component.ts
@@ -1,11 +1,52 @@
 import 'chartjs-adapter-date-fns';
 import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Input, OnChanges } from '@angular/core';
-import { ChartData, ChartOptions, LineController, LineElement, LinearScale, PointElement, TimeScale, Tooltip } from 'chart.js';
+import {
+  ChartData,
+  ChartOptions,
+  Interaction,
+  InteractionItem,
+  InteractionModeFunction,
+  LineController,
+  LineElement,
+  LinearScale,
+  Plugin,
+  PointElement,
+  TimeScale,
+  Tooltip,
+} from 'chart.js';
+import { startOfDay } from 'date-fns';
 import { BaseChartDirective, provideCharts } from 'ng2-charts';
 import { ExerciseSeriesViewModel } from '@features/progress/models/progress-page.viewmodel';
 
 const FALLBACK_SERIES_COLOR = '#49454f';
+
+declare module 'chart.js' {
+  interface InteractionModeMap {
+    dayX: InteractionModeFunction;
+  }
+}
+
+const dayXInteractionMode: InteractionModeFunction = (chart, event, options, useFinalPosition) => {
+  const nearest = Interaction.modes.nearest(chart, event, { ...options, axis: 'x', intersect: false }, useFinalPosition);
+  if (nearest.length === 0) {
+    return nearest;
+  }
+
+  // Points are normalized to day precision, so points of one day share their pixel x.
+  const targetX = nearest[0].element.x;
+  const items: InteractionItem[] = [];
+  for (const meta of chart.getSortedVisibleDatasetMetas()) {
+    meta.data.forEach((element, index) => {
+      if (Math.abs(element.x - targetX) < 1) {
+        items.push({ element, datasetIndex: meta.index, index });
+      }
+    });
+  }
+  return items;
+};
+
+Interaction.modes.dayX = dayXInteractionMode;
 
 interface ProgressChartDataPoint {
   x: number;
@@ -30,6 +71,9 @@ export class ProgressChartComponent implements OnChanges {
 
   chartData: ChartData<'line', ProgressChartDataPoint[]> = { datasets: [] };
   chartOptions: ChartOptions<'line'> = {};
+  readonly chartPlugins: Plugin<'line'>[] = [this.createSelectedDayLinePlugin()];
+
+  private selectedDayLineColor = FALLBACK_SERIES_COLOR;
 
   ngOnChanges(): void {
     this.chartData = {
@@ -39,7 +83,7 @@ export class ProgressChartComponent implements OnChanges {
         return {
           label: s.exerciseName,
           data: s.points.map(p => ({
-            x: new Date(p.date).getTime(),
+            x: startOfDay(new Date(p.date)).getTime(),
             y: p.weight,
             repsLabel: p.repsLabel,
             planName: p.planName,
@@ -59,11 +103,12 @@ export class ProgressChartComponent implements OnChanges {
   private buildOptions(): ChartOptions<'line'> {
     const textColor = this.getThemeColor('--mat-sys-on-surface-variant', '#49454f');
     const gridColor = this.getThemeColor('--mat-sys-outline-variant', '#cac4d0');
+    this.selectedDayLineColor = textColor;
 
     return {
       responsive: true,
       maintainAspectRatio: false,
-      interaction: { mode: 'nearest', intersect: false },
+      interaction: { mode: 'dayX', intersect: false },
       scales: {
         x: {
           type: 'time',
@@ -92,6 +137,30 @@ export class ProgressChartComponent implements OnChanges {
             },
           },
         },
+      },
+    };
+  }
+
+  private createSelectedDayLinePlugin(): Plugin<'line'> {
+    return {
+      id: 'txgSelectedDayLine',
+      afterDatasetsDraw: chart => {
+        const active = chart.tooltip?.getActiveElements() ?? [];
+        if (active.length === 0) {
+          return;
+        }
+
+        const { top, bottom } = chart.chartArea;
+        const ctx = chart.ctx;
+        ctx.save();
+        ctx.beginPath();
+        ctx.setLineDash([4, 4]);
+        ctx.lineWidth = 1;
+        ctx.strokeStyle = this.selectedDayLineColor;
+        ctx.moveTo(active[0].element.x, top);
+        ctx.lineTo(active[0].element.x, bottom);
+        ctx.stroke();
+        ctx.restore();
       },
     };
   }

--- a/apps/web/src/app/features/progress/pages/progress-page/progress-page.facade.ts
+++ b/apps/web/src/app/features/progress/pages/progress-page/progress-page.facade.ts
@@ -94,7 +94,7 @@ export class ProgressPageFacade {
       options.selectAll || previouslySelectedIds.has(exerciseId) || !previousIds.has(exerciseId);
 
     this.progressService.getExerciseProgress(queryParams).pipe(
-      map(response => mapToExerciseSeriesViewModels(response.data ?? [], this.internalPlans(), isSelected)),
+      map(response => mapToExerciseSeriesViewModels(response.data ?? [], this.internalPlans(), isSelected, filters.selectedPlanId)),
       catchError((error: Error) => {
         console.error('Error loading exercise progress:', error);
         this.viewModel.update(vm => ({


### PR DESCRIPTION
## Summary
- Order exercise series/chips by their appearance in the plan (oldest plan first, then day and exercise order) instead of alphabetically; a selected plan filter scopes the ordering to that plan.
- Scope chart presses to full days: a press activates every point of the nearest day and the tooltip lists all exercises of that session, with a dashed vertical line marking the selected day.
- Add spacing under the exercise chip row so the horizontal scrollbar no longer overlays the chips.

## Test plan
- `pnpm --filter @txg/web test` (306 tests, includes new mapping specs)
- `pnpm --filter @txg/web lint`
- Verified against the local stack: chip order, day-scoped tooltip + dashed line, chip scrollbar spacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)