### PR TITLE
fix(web): Keep the date range field's suffix buttons on one line

### DIFF
--- a/apps/web/src/app/shared/ui/components/date-range-field/date-range-field.component.scss
+++ b/apps/web/src/app/shared/ui/components/date-range-field/date-range-field.component.scss
@@ -2,10 +2,6 @@
   position: relative;
 }
 
-// The suffix holds two buttons where Material's fields usually hold one. It is a flex item that
-// shrinks by default, and its buttons are inline-level, so a narrow viewport squeezes the box and
-// wraps them onto a second line. Hold its width and keep the buttons inline; the date inputs
-// (which do shrink) give up the space instead.
 :host ::ng-deep .mat-mdc-form-field-icon-suffix {
   flex-shrink: 0;
   white-space: nowrap;
@@ -16,12 +12,10 @@
   inset: 0;
   display: flex;
   align-items: center;
-  pointer-events: none; // Clicks and focus fall through to the real inputs underneath.
+  pointer-events: none;
   color: var(--mat-sys-on-surface);
 }
 
-// While a preset is active the raw dates are hidden (not removed): the inputs stay mounted and
-// typeable, so the first keystroke clears the preset and the real values reappear.
 :host ::ng-deep .txg-preset-active {
   .mat-date-range-input-inner {
     color: transparent;

--- a/apps/web/src/app/shared/ui/components/date-range-field/date-range-field.component.scss
+++ b/apps/web/src/app/shared/ui/components/date-range-field/date-range-field.component.scss
@@ -2,6 +2,15 @@
   position: relative;
 }
 
+// The suffix holds two buttons where Material's fields usually hold one. It is a flex item that
+// shrinks by default, and its buttons are inline-level, so a narrow viewport squeezes the box and
+// wraps them onto a second line. Hold its width and keep the buttons inline; the date inputs
+// (which do shrink) give up the space instead.
+:host ::ng-deep .mat-mdc-form-field-icon-suffix {
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
 .txg-preset-label {
   position: absolute;
   inset: 0;

--- a/cypress/e2e/history/history.cy.ts
+++ b/cypress/e2e/history/history.cy.ts
@@ -2,9 +2,6 @@ import { dataCy } from '../../support/selectors';
 
 const daysAgo = (days: number): Date => new Date(Date.now() - days * 24 * 60 * 60 * 1000);
 const formatDate = (date: Date): string => `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()}`;
-
-// The scaffold lays completed sessions at 32, 30, 27, 25, 23, 20, 18, 16, 13, 11, 9, 6, 4 and
-// 2 days ago; this window covers the first six of them.
 const FILTER_DATE_FROM = formatDate(daysAgo(33));
 const FILTER_DATE_TO = formatDate(daysAgo(19));
 


### PR DESCRIPTION
## Summary

At narrow widths the date range field's two suffix buttons — the preset menu and the calendar toggle — wrapped onto a second line, leaving the control two rows tall.

## Cause

`.mat-mdc-form-field-icon-suffix` is a flex item with `flex-shrink: 1`, and its children are inline-level with `white-space: normal`. This field carries **two** suffix buttons where Material's fields normally carry one, so once the viewport narrows the suffix box is squeezed below their combined width and the buttons wrap.

Measured in the browser at 360px, before:

```
presetTop: 318   toggleTop: 354   wrapped: true
flexShrink: "1"  whiteSpace: "normal"
suffixWidth: 69  suffixHeight: 73   <- two stacked rows
```

69px of box for ~96px of buttons.

## Fix

Hold the suffix's width and keep its buttons inline. The date inputs shrink instead, which is the right trade: the date text truncates, the controls stay put.

```scss
:host ::ng-deep .mat-mdc-form-field-icon-suffix {
  flex-shrink: 0;
  white-space: nowrap;
}
```

After, at 360px:

```
presetTop: 337   toggleTop: 337   wrapped: false
flexShrink: "0"  whiteSpace: "nowrap"
suffixWidth: 73  suffixHeight: 35   <- back to one row
```

## Testing

Measured at **360, 320 and 280px** — both buttons share a line at every width, and the suffix is a single 35px row rather than 73px. `pnpm lint` and the 323 web unit tests pass.

Follow-up to #49, which merged before this landed.
