### PR TITLE
feat(web): Add ephemeral warmup set bubbles to the session page

### DIFF
--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -59,6 +59,34 @@ alias_port "${TXG_SUPABASE_PORT:-54321}" 54321
 alias_port "${TXG_STUDIO_PORT:-54323}" 54323
 alias_port "${TXG_MAIL_PORT:-54324}" 54324
 
+# Cypress runs Electron, which needs an X server. The container inherits the host's DISPLAY
+# (WSLg passthrough) with no socket behind it, and a set-but-dead DISPLAY keeps Cypress from
+# falling back to its own Xvfb - Electron aborts with "Missing X server or $DISPLAY". Back
+# the advertised display with a headless X server on every start. Guard on the process, not
+# the socket file: a container stop SIGKILLs Xvfb, which then leaves a stale socket behind
+# that would otherwise suppress the relaunch forever.
+XVFB_DISPLAY="${DISPLAY:-:0}"
+XVFB_DISPLAY="${XVFB_DISPLAY%%.*}"
+XVFB_COMMAND="Xvfb ${XVFB_DISPLAY} -screen 0 1280x800x24"
+case "$XVFB_DISPLAY" in
+  :[0-9]*)
+    if ! pgrep -fx "$XVFB_COMMAND" >/dev/null; then
+      rm -f "/tmp/.X11-unix/X${XVFB_DISPLAY#:}" "/tmp/.X${XVFB_DISPLAY#:}-lock"
+      # shellcheck disable=SC2086 # word splitting builds the argument list
+      nohup $XVFB_COMMAND >/dev/null 2>&1 &
+      if timeout 10 bash -c "until [ -S '/tmp/.X11-unix/X${XVFB_DISPLAY#:}' ]; do sleep 0.2; done"; then
+        echo "Started Xvfb on ${XVFB_DISPLAY} for Cypress."
+      else
+        echo "Warning: Xvfb did not come up on ${XVFB_DISPLAY}; Cypress will not run." >&2
+      fi
+    fi
+    ;;
+  *)
+    # A hostname-bearing DISPLAY (e.g. SSH X forwarding) is not something Xvfb can serve.
+    echo "DISPLAY='${DISPLAY:-}' is not a local ':N' display; skipping Xvfb for Cypress." >&2
+    ;;
+esac
+
 # Point the three gitignored config files at the running stack (fresh keys on every recreate,
 # hence every start). Only the derived values are rewritten; other lines a developer added
 # are left intact.

--- a/.github/workflows/on-pull-request-main.yml
+++ b/.github/workflows/on-pull-request-main.yml
@@ -97,6 +97,9 @@ jobs:
 
             if (cdJobs.length === 0) return;
 
+            // A manually cancelled run marks every CD job as cancelled (or skipped); there is nothing to report.
+            if (cdJobs.every(job => job.conclusion === 'cancelled' || job.conclusion === 'skipped')) return;
+
             let commentBody = '### CD Job Results\n\n';
             commentBody += '| Job | Status | Details |\n';
             commentBody += '|-----|--------|---------|\n';

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,10 +45,11 @@ Use the Conventional Commits format: `<type>(<optional scope>): <Description>`
 - Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`.
 - The type and scope MUST be lowercase; the first letter after the colon MUST be capitalized.
 - Use imperative mood ("Add feature", not "Added feature"); no period at the end; keep the description under 72 characters.
-- Scope by project area, e.g. `web`, `api`, `shared`, `db`, `auth`, `cd`, `config`.
+- Prefer the feature scope when a change is confined to one product feature, e.g. `sessions`, `plans`, `progress`, `home`, `auth` — regardless of which packages it touches.
+- Scope by project area for cross-feature or infrastructure changes, e.g. `web`, `api`, `shared`, `db`, `cd`, `config`.
 - One logical change per commit. For breaking changes, add `!` after the type/scope and a `BREAKING CHANGE:` body explaining the impact.
 
-Examples: `feat(web): Add profile image upload feature`, `fix(auth): Resolve token validation issue`.
+Examples: `feat(settings): Add profile image upload feature`, `fix(auth): Resolve token validation issue`, `chore(config): Bump the pnpm version`.
 
 ## Additional Notes
 

--- a/apps/web/src/app/features/sessions/models/session-page.viewmodel.ts
+++ b/apps/web/src/app/features/sessions/models/session-page.viewmodel.ts
@@ -26,6 +26,12 @@ export interface SessionExerciseViewModel {
   plannedSetsCount: number;
 }
 
+export interface SessionWarmupSetViewModel {
+  id: string;
+  reps: number;
+  weight: number;
+}
+
 export interface SessionSetViewModel {
   id: string;
   planExerciseId: string;

--- a/apps/web/src/app/features/sessions/pages/session-page/components/_bubble.scss
+++ b/apps/web/src/app/features/sessions/pages/session-page/components/_bubble.scss
@@ -1,0 +1,25 @@
+// Shared form factor for the 48px bubbles (working sets, warmups, add action) rendered side
+// by side in the session set row - they must stay pixel-identical to keep the row aligned.
+
+@mixin bubble-button {
+  width: 48px;
+  height: 48px;
+  min-width: auto;
+  overflow: hidden;
+  line-height: normal;
+}
+
+@mixin bubble-labels {
+  .bubble-text {
+    font-size: 1.25rem;
+    font-weight: 500;
+    line-height: 1;
+  }
+
+  .bubble-weight-text {
+    font-size: 0.625rem;
+    font-weight: 400;
+    line-height: 1;
+    margin-top: 1px;
+  }
+}

--- a/apps/web/src/app/features/sessions/pages/session-page/components/session-exercise-item/session-exercise-item.component.html
+++ b/apps/web/src/app/features/sessions/pages/session-page/components/session-exercise-item/session-exercise-item.component.html
@@ -1,4 +1,4 @@
-<mat-card class="exercise-item-card mb-4">
+<mat-card class="exercise-item-card mb-4" data-cy="session-exercise-item">
   <mat-card-header class="!flex !justify-between !items-start mb-6">
     <div class="flex-grow">
       <mat-card-title class="!text-lg !font-semibold">

--- a/apps/web/src/app/features/sessions/pages/session-page/components/session-set-bubble/session-set-bubble.component.html
+++ b/apps/web/src/app/features/sessions/pages/session-page/components/session-set-bubble/session-set-bubble.component.html
@@ -7,11 +7,11 @@
     (txgClick)="onSetClicked()"
     (txgLongPress)="onSetLongPressed()">
     <div class="flex flex-col items-center justify-center">
-      <span class="text-xl font-medium leading-none" data-cy="set-bubble-text">
+      <span class="bubble-text" data-cy="set-bubble-text">
         {{ bubbleText }}
       </span>
       @if (bubbleWeightText) {
-        <span class="text-[0.625rem] font-normal leading-none mt-px" data-cy="set-bubble-weight-text">
+        <span class="bubble-weight-text" data-cy="set-bubble-weight-text">
           {{ bubbleWeightText }}
         </span>
       }

--- a/apps/web/src/app/features/sessions/pages/session-page/components/session-set-bubble/session-set-bubble.component.scss
+++ b/apps/web/src/app/features/sessions/pages/session-page/components/session-set-bubble/session-set-bubble.component.scss
@@ -1,10 +1,9 @@
+@use '../bubble' as bubble;
+
 button {
-  width: 48px;
-  height: 48px;
-  min-width: auto;
+  @include bubble.bubble-button;
+  @include bubble.bubble-labels;
   transition: background-color 0.3s ease, color 0.3s ease;
-  overflow: hidden;
-  line-height: normal;
 
   &:disabled {
     cursor: not-allowed;

--- a/apps/web/src/app/features/sessions/pages/session-page/components/session-set-list/session-set-list.component.html
+++ b/apps/web/src/app/features/sessions/pages/session-page/components/session-set-list/session-set-list.component.html
@@ -1,8 +1,24 @@
-<div txgAutoHideScrollbar class="flex flex-nowrap gap-2 pb-3 items-center overflow-x-auto">
-  @for (set of exercise.sets; track set.id; let i = $index) {
+<div txgAutoHideScrollbar class="flex flex-nowrap gap-2 px-[2px] pb-3 items-center overflow-x-auto">
+  @switch (warmupState()) {
+    @case ('collapsed') {
+      <txg-session-warmup-bubble
+        [isToggle]="true"
+        (bubbleClicked)="onWarmupToggleClicked()">
+      </txg-session-warmup-bubble>
+    }
+    @case ('expanded') {
+      @for (warmupSet of warmupSets(); track warmupSet.id; let i = $index) {
+        <txg-session-warmup-bubble
+          animate.enter="warmup-bubble-enter"
+          [style.--warmup-enter-delay]="i * 30 + 'ms'"
+          [warmupSet]="warmupSet"
+          (bubbleClicked)="onWarmupSetClicked(warmupSet.id)">
+        </txg-session-warmup-bubble>
+      }
+    }
+  }
+  @for (set of exercise.sets; track set.id) {
     <txg-session-set-bubble
-      [class.ml-[2px]]="i === 0"
-      [class.mr-[2px]]="isReadOnly && i === exercise.sets.length - 1"
       [set]="set"
       [isReadOnly]="isReadOnly"
       (setClicked)="onSetClicked($event)"
@@ -10,7 +26,7 @@
     </txg-session-set-bubble>
   }
   @if (!isReadOnly) {
-    <txg-session-set-bubble class="mr-[2px]"
+    <txg-session-set-bubble
       [isAddAction]="true"
       [isReadOnly]="isReadOnly"
       (setAdded)="onSetAdded()">

--- a/apps/web/src/app/features/sessions/pages/session-page/components/session-set-list/session-set-list.component.scss
+++ b/apps/web/src/app/features/sessions/pages/session-page/components/session-set-list/session-set-list.component.scss
@@ -1,0 +1,22 @@
+@keyframes warmup-bubble-in {
+  from {
+    opacity: 0;
+    transform: scale(0.6);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+txg-session-warmup-bubble.warmup-bubble-enter {
+  // `backwards` holds the from-state through the staggered delay.
+  animation: warmup-bubble-in 150ms ease-out backwards;
+  animation-delay: var(--warmup-enter-delay, 0ms);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  txg-session-warmup-bubble.warmup-bubble-enter {
+    animation: none;
+  }
+}

--- a/apps/web/src/app/features/sessions/pages/session-page/components/session-set-list/session-set-list.component.spec.ts
+++ b/apps/web/src/app/features/sessions/pages/session-page/components/session-set-list/session-set-list.component.spec.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SessionSetListComponent } from './session-set-list.component';
+import { SessionExerciseViewModel, SessionSetViewModel } from '../../../../models/session-page.viewmodel';
+
+const createMockSet = (overrides: Partial<SessionSetViewModel> = {}): SessionSetViewModel => ({
+  id: 'set1',
+  order: 1,
+  status: 'PENDING',
+  expectedReps: 5,
+  weight: 70,
+  actualReps: undefined,
+  planExerciseId: 'tpex1',
+  ...overrides,
+});
+
+const createMockExercise = (overrides: Partial<SessionExerciseViewModel> = {}): SessionExerciseViewModel => ({
+  planExerciseId: 'tpex1',
+  exerciseName: 'Squat',
+  order: 1,
+  plannedSetsCount: 3,
+  sets: [
+    createMockSet({ id: 'set1', order: 1 }),
+    createMockSet({ id: 'set2', order: 2 }),
+    createMockSet({ id: 'set3', order: 3 }),
+  ],
+  ...overrides,
+});
+
+describe('SessionSetListComponent', () => {
+  let component: SessionSetListComponent;
+
+  beforeEach(() => {
+    component = new SessionSetListComponent();
+    component.exercise = createMockExercise();
+  });
+
+  describe('Warmup Visibility', () => {
+    it('should be collapsed with a computed ramp when all sets are PENDING', () => {
+      expect(component.warmupState()).toBe('collapsed');
+      expect(component.warmupSets().map(s => ({ reps: s.reps, weight: s.weight }))).toEqual([
+        { reps: 5, weight: 20 },
+        { reps: 5, weight: 20 },
+        { reps: 5, weight: 32.5 },
+        { reps: 3, weight: 45 },
+        { reps: 2, weight: 57.5 },
+      ]);
+    });
+
+    it('should be dismissed when any set has a non-PENDING status', () => {
+      for (const status of ['COMPLETED', 'FAILED', 'SKIPPED'] as const) {
+        component.exercise = createMockExercise({
+          sets: [createMockSet({ id: 'set1', status }), createMockSet({ id: 'set2' })],
+        });
+
+        expect(component.warmupState(), `should be dismissed for status ${status}`).toBe('dismissed');
+      }
+    });
+
+    it('should be dismissed when the session is read-only', () => {
+      component.isReadOnly = true;
+      expect(component.warmupState()).toBe('dismissed');
+    });
+
+    it('should be dismissed when no warmup sets can be computed', () => {
+      component.exercise = createMockExercise({
+        sets: [createMockSet({ weight: undefined }), createMockSet({ id: 'set2', weight: 0 })],
+      });
+
+      expect(component.warmupState()).toBe('dismissed');
+      expect(component.warmupSets()).toEqual([]);
+    });
+
+    it('should compute the warmup from the heaviest set (top-set weight)', () => {
+      component.exercise = createMockExercise({
+        sets: [
+          createMockSet({ id: 'set1', weight: 60 }),
+          createMockSet({ id: 'set2', weight: 70 }),
+          createMockSet({ id: 'set3', weight: 65 }),
+        ],
+      });
+
+      const warmupSets = component.warmupSets();
+      expect(warmupSets[warmupSets.length - 1]?.weight).toBe(57.5); // 20 + 3 * (70 - 20) / 4
+    });
+
+    it('should recompute the ramp when a set weight is edited', () => {
+      component.exercise = createMockExercise({
+        sets: [createMockSet({ id: 'set1', weight: 100 }), createMockSet({ id: 'set2', weight: 100 })],
+      });
+      expect(component.warmupSets().map(s => s.weight)).toEqual([20, 20, 40, 60, 80]);
+
+      component.exercise = createMockExercise({
+        sets: [createMockSet({ id: 'set1', weight: 50 }), createMockSet({ id: 'set2', weight: 50 })],
+      });
+
+      expect(component.warmupSets().map(s => s.weight)).toEqual([20, 20, 27.5, 35, 42.5]);
+    });
+  });
+
+  describe('Warmup Interactions', () => {
+    it('should expand when the toggle is clicked', () => {
+      component.onWarmupToggleClicked();
+      expect(component.warmupState()).toBe('expanded');
+    });
+
+    it('should remove only the clicked warmup set', () => {
+      component.onWarmupToggleClicked();
+      const initialSets = component.warmupSets();
+
+      component.onWarmupSetClicked(initialSets[2].id);
+
+      expect(component.warmupSets()).toHaveLength(initialSets.length - 1);
+      expect(component.warmupSets().map(s => s.id)).not.toContain(initialSets[2].id);
+      expect(component.warmupState()).toBe('expanded');
+    });
+
+    it('should dismiss when the last warmup set is removed', () => {
+      component.onWarmupToggleClicked();
+
+      for (const warmupSet of [...component.warmupSets()]) {
+        component.onWarmupSetClicked(warmupSet.id);
+      }
+
+      expect(component.warmupSets()).toEqual([]);
+      expect(component.warmupState()).toBe('dismissed');
+    });
+  });
+
+  describe('Dismissal via Working Sets', () => {
+    it('should re-emit setClicked unchanged', () => {
+      const spy = vi.spyOn(component.setClicked, 'emit');
+      const clickedSet = component.exercise.sets[0];
+
+      component.onSetClicked(clickedSet);
+
+      expect(spy).toHaveBeenCalledWith(clickedSet);
+    });
+
+    it('should dismiss when the optimistic update marks a set non-PENDING', () => {
+      component.onWarmupToggleClicked();
+      expect(component.warmupState()).toBe('expanded');
+
+      // The facade applies the optimistic set update by re-binding a new exercise object.
+      component.exercise = createMockExercise({
+        sets: [createMockSet({ id: 'set1', status: 'COMPLETED', actualReps: 5 }), createMockSet({ id: 'set2' })],
+      });
+
+      expect(component.warmupState()).toBe('dismissed');
+    });
+
+    it('should restore the warmup UI when a failed patch reverts the set to PENDING', () => {
+      component.onWarmupToggleClicked();
+      const removedId = component.warmupSets()[0].id;
+      component.onWarmupSetClicked(removedId);
+
+      component.exercise = createMockExercise({
+        sets: [createMockSet({ id: 'set1', status: 'COMPLETED', actualReps: 5 }), createMockSet({ id: 'set2' })],
+      });
+      expect(component.warmupState()).toBe('dismissed');
+
+      // The API rejects the update and the facade restores the PENDING snapshot.
+      component.exercise = createMockExercise({
+        sets: [createMockSet({ id: 'set1' }), createMockSet({ id: 'set2' })],
+      });
+
+      expect(component.warmupState()).toBe('expanded');
+      expect(component.warmupSets().map(s => s.id)).not.toContain(removedId);
+    });
+  });
+
+  describe('Existing Behavior', () => {
+    it('should re-emit setLongPressed unchanged', () => {
+      const spy = vi.spyOn(component.setLongPressed, 'emit');
+      const set = component.exercise.sets[1];
+
+      component.onSetLongPressed(set);
+
+      expect(spy).toHaveBeenCalledWith(set);
+      expect(component.warmupState()).toBe('collapsed');
+    });
+
+    it('should emit setAdded with the exercise id', () => {
+      const spy = vi.spyOn(component.setAdded, 'emit');
+
+      component.onSetAdded();
+
+      expect(spy).toHaveBeenCalledWith('tpex1');
+    });
+  });
+});

--- a/apps/web/src/app/features/sessions/pages/session-page/components/session-set-list/session-set-list.component.ts
+++ b/apps/web/src/app/features/sessions/pages/session-page/components/session-set-list/session-set-list.component.ts
@@ -1,31 +1,71 @@
-import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
-import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, computed, signal } from '@angular/core';
 import { AutoHideScrollbarDirective } from '@shared/utils/directives/auto-hide-scrollbar.directive';
-import { SessionExerciseViewModel, SessionSetViewModel } from '../../../../models/session-page.viewmodel';
+import { SessionExerciseViewModel, SessionSetViewModel, SessionWarmupSetViewModel } from '../../../../models/session-page.viewmodel';
+import { calculateWarmupSets } from '../../utils/warmup.utils';
 import { SessionSetBubbleComponent } from '../session-set-bubble/session-set-bubble.component';
+import { SessionWarmupBubbleComponent } from '../session-warmup-bubble/session-warmup-bubble.component';
+
+type WarmupDisplayState = 'collapsed' | 'expanded' | 'dismissed';
 
 @Component({
   selector: 'txg-session-set-list',
   standalone: true,
   imports: [
-    CommonModule,
     SessionSetBubbleComponent,
-    MatButtonModule,
-    MatIconModule,
+    SessionWarmupBubbleComponent,
     AutoHideScrollbarDirective,
   ],
   templateUrl: './session-set-list.component.html',
+  styleUrl: './session-set-list.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SessionSetListComponent {
-  @Input() exercise!: SessionExerciseViewModel;
-  @Input() isReadOnly: boolean = false;
+  private readonly exerciseSignal = signal<SessionExerciseViewModel | null>(null);
+  private readonly readOnlySignal = signal<boolean>(false);
+
+  @Input({ required: true }) set exercise(value: SessionExerciseViewModel) {
+    this.exerciseSignal.set(value);
+  }
+  get exercise(): SessionExerciseViewModel {
+    return this.exerciseSignal()!;
+  }
+
+  @Input() set isReadOnly(value: boolean) {
+    this.readOnlySignal.set(value);
+  }
+  get isReadOnly(): boolean {
+    return this.readOnlySignal();
+  }
 
   @Output() setClicked = new EventEmitter<SessionSetViewModel>();
   @Output() setLongPressed = new EventEmitter<SessionSetViewModel>();
   @Output() setAdded = new EventEmitter<string>();
+
+  private readonly expanded = signal<boolean>(false);
+  private readonly removedWarmupSetIds = signal<readonly string[]>([]);
+
+  readonly warmupSets = computed<SessionWarmupSetViewModel[]>(() => {
+    const sets = this.exerciseSignal()?.sets ?? [];
+    const workingWeight = Math.max(0, ...sets.map(s => s.weight ?? 0));
+    const removedIds = this.removedWarmupSetIds();
+    return calculateWarmupSets(workingWeight).filter(s => !removedIds.includes(s.id));
+  });
+
+  readonly warmupState = computed<WarmupDisplayState>(() => {
+    const hasInteractedSets = (this.exerciseSignal()?.sets ?? []).some(s => s.status !== 'PENDING');
+    if (this.readOnlySignal() || hasInteractedSets || this.warmupSets().length === 0) {
+      return 'dismissed';
+    }
+    return this.expanded() ? 'expanded' : 'collapsed';
+  });
+
+  onWarmupToggleClicked(): void {
+    this.expanded.set(true);
+  }
+
+  onWarmupSetClicked(warmupSetId: string): void {
+    this.removedWarmupSetIds.update(ids => [...ids, warmupSetId]);
+  }
 
   onSetClicked(set: SessionSetViewModel): void {
     this.setClicked.emit(set);

--- a/apps/web/src/app/features/sessions/pages/session-page/components/session-warmup-bubble/session-warmup-bubble.component.html
+++ b/apps/web/src/app/features/sessions/pages/session-page/components/session-warmup-bubble/session-warmup-bubble.component.html
@@ -1,0 +1,22 @@
+@if (isToggle) {
+  <button mat-stroked-button txgLongPress class="warmup-bubble"
+    aria-label="Show warmup sets"
+    data-cy="warmup-toggle-bubble"
+    (txgClick)="onBubbleClicked()">
+    <span class="bubble-text">W</span>
+  </button>
+} @else if (warmupSet) {
+  <button mat-stroked-button txgLongPress class="warmup-bubble"
+    aria-label="Dismiss warmup set"
+    data-cy="warmup-set-bubble"
+    (txgClick)="onBubbleClicked()">
+    <div class="flex flex-col items-center justify-center">
+      <span class="bubble-text" data-cy="warmup-set-bubble-text">
+        {{ warmupSet.reps }}
+      </span>
+      <span class="bubble-weight-text" data-cy="warmup-set-bubble-weight-text">
+        {{ warmupSet.weight }}
+      </span>
+    </div>
+  </button>
+}

--- a/apps/web/src/app/features/sessions/pages/session-page/components/session-warmup-bubble/session-warmup-bubble.component.scss
+++ b/apps/web/src/app/features/sessions/pages/session-page/components/session-warmup-bubble/session-warmup-bubble.component.scss
@@ -1,0 +1,8 @@
+@use '../bubble' as bubble;
+
+button.warmup-bubble {
+  @include bubble.bubble-button;
+  @include bubble.bubble-labels;
+  border-style: dashed;
+  color: var(--mat-sys-secondary);
+}

--- a/apps/web/src/app/features/sessions/pages/session-page/components/session-warmup-bubble/session-warmup-bubble.component.spec.ts
+++ b/apps/web/src/app/features/sessions/pages/session-page/components/session-warmup-bubble/session-warmup-bubble.component.spec.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SessionWarmupBubbleComponent } from './session-warmup-bubble.component';
+import { SessionWarmupSetViewModel } from '../../../../models/session-page.viewmodel';
+
+const createMockWarmupSet = (overrides: Partial<SessionWarmupSetViewModel> = {}): SessionWarmupSetViewModel => ({
+  id: 'warmup-0',
+  reps: 5,
+  weight: 32.5,
+  ...overrides,
+});
+
+describe('SessionWarmupBubbleComponent', () => {
+  let component: SessionWarmupBubbleComponent;
+
+  beforeEach(() => {
+    component = new SessionWarmupBubbleComponent();
+  });
+
+  it('should emit bubbleClicked exactly once per click in toggle mode', () => {
+    component.isToggle = true;
+    const spy = vi.spyOn(component.bubbleClicked, 'emit');
+
+    component.onBubbleClicked();
+
+    expect(spy).toHaveBeenCalledOnce();
+  });
+
+  it('should emit bubbleClicked exactly once per click in warmup set mode, without mutating the set', () => {
+    component.warmupSet = createMockWarmupSet({ reps: 3, weight: 45 });
+    const spy = vi.spyOn(component.bubbleClicked, 'emit');
+    const originalSet = { ...component.warmupSet };
+
+    component.onBubbleClicked();
+
+    expect(spy).toHaveBeenCalledOnce();
+    expect(component.warmupSet).toEqual(originalSet);
+  });
+});

--- a/apps/web/src/app/features/sessions/pages/session-page/components/session-warmup-bubble/session-warmup-bubble.component.ts
+++ b/apps/web/src/app/features/sessions/pages/session-page/components/session-warmup-bubble/session-warmup-bubble.component.ts
@@ -1,0 +1,26 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { LongPressDirective } from '@shared/utils/directives/long-press.directive';
+import { SessionWarmupSetViewModel } from '../../../../models/session-page.viewmodel';
+
+@Component({
+  selector: 'txg-session-warmup-bubble',
+  standalone: true,
+  imports: [
+    MatButtonModule,
+    LongPressDirective,
+  ],
+  templateUrl: './session-warmup-bubble.component.html',
+  styleUrl: './session-warmup-bubble.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SessionWarmupBubbleComponent {
+  @Input() warmupSet?: SessionWarmupSetViewModel;
+  @Input() isToggle: boolean = false;
+
+  @Output() bubbleClicked = new EventEmitter<void>();
+
+  onBubbleClicked(): void {
+    this.bubbleClicked.emit();
+  }
+}

--- a/apps/web/src/app/features/sessions/pages/session-page/utils/warmup.utils.spec.ts
+++ b/apps/web/src/app/features/sessions/pages/session-page/utils/warmup.utils.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { calculateWarmupSets, WARMUP_SCHEME } from './warmup.utils';
+
+describe('calculateWarmupSets', () => {
+  it('should compute the canonical even-jump ramp for a 70 kg working weight', () => {
+    const sets = calculateWarmupSets(70);
+
+    expect(sets.map(s => ({ reps: s.reps, weight: s.weight }))).toMatchInlineSnapshot(`
+      [
+        {
+          "reps": 5,
+          "weight": 20,
+        },
+        {
+          "reps": 5,
+          "weight": 20,
+        },
+        {
+          "reps": 5,
+          "weight": 32.5,
+        },
+        {
+          "reps": 3,
+          "weight": 45,
+        },
+        {
+          "reps": 2,
+          "weight": 57.5,
+        },
+      ]
+    `);
+  });
+
+  it('should round ramp weights to the nearest weight step for non-round working weights', () => {
+    const sets = calculateWarmupSets(67.5);
+
+    const rampWeights = sets.slice(WARMUP_SCHEME.barSets.count).map(s => s.weight);
+    expect(rampWeights).toEqual([32.5, 45, 55]);
+    for (const set of sets) {
+      expect(set.weight % WARMUP_SCHEME.weightStepKg, `weight ${set.weight} should be a multiple of the step`).toBe(0);
+    }
+  });
+
+  it('should return an empty list when the working weight does not exceed the bar', () => {
+    expect(calculateWarmupSets(20)).toEqual([]);
+    expect(calculateWarmupSets(15)).toEqual([]);
+  });
+
+  it('should return an empty list for missing or zero working weight', () => {
+    expect(calculateWarmupSets(undefined)).toEqual([]);
+    expect(calculateWarmupSets(0)).toEqual([]);
+  });
+
+  it('should drop colliding ramp sets for working weights slightly above the bar', () => {
+    const sets = calculateWarmupSets(25);
+
+    expect(sets.map(s => ({ reps: s.reps, weight: s.weight }))).toEqual([
+      { reps: 5, weight: 20 },
+      { reps: 5, weight: 20 },
+      { reps: 5, weight: 22.5 },
+    ]);
+  });
+
+  it('should keep only the bar sets when every rounded ramp weight collides', () => {
+    const sets = calculateWarmupSets(22.5);
+
+    expect(sets.map(s => ({ reps: s.reps, weight: s.weight }))).toEqual([
+      { reps: 5, weight: 20 },
+      { reps: 5, weight: 20 },
+    ]);
+  });
+
+  it('should produce strictly increasing ramp weights below the working weight', () => {
+    for (const workingWeight of [25, 30, 42.5, 60, 100, 137.5, 250]) {
+      const rampWeights = calculateWarmupSets(workingWeight)
+        .slice(WARMUP_SCHEME.barSets.count)
+        .map(s => s.weight);
+
+      for (let i = 0; i < rampWeights.length; i++) {
+        const previous = i === 0 ? WARMUP_SCHEME.barWeightKg : rampWeights[i - 1];
+        expect(rampWeights[i], `ramp weights for ${workingWeight} kg should increase`).toBeGreaterThan(previous);
+        expect(rampWeights[i], `ramp weights for ${workingWeight} kg should stay below the working weight`).toBeLessThan(workingWeight);
+      }
+    }
+  });
+
+  it('should assign a unique id to every returned set', () => {
+    const sets = calculateWarmupSets(70);
+    const ids = new Set(sets.map(s => s.id));
+
+    expect(ids.size).toBe(sets.length);
+  });
+});

--- a/apps/web/src/app/features/sessions/pages/session-page/utils/warmup.utils.ts
+++ b/apps/web/src/app/features/sessions/pages/session-page/utils/warmup.utils.ts
@@ -1,0 +1,42 @@
+import { SessionWarmupSetViewModel } from '../../../models/session-page.viewmodel';
+
+/**
+ * Starting Strength even-jump warmup scheme: two sets of five with the empty
+ * bar, then ramp sets at even weight jumps between the bar and the working
+ * weight, with descending reps to limit fatigue.
+ */
+export const WARMUP_SCHEME = {
+  barWeightKg: 20,
+  barSets: { count: 2, reps: 5 },
+  rampReps: [5, 3, 2],
+  weightStepKg: 2.5,
+} as const;
+
+export function calculateWarmupSets(workingWeight: number | undefined): SessionWarmupSetViewModel[] {
+  const { barWeightKg, barSets, rampReps, weightStepKg } = WARMUP_SCHEME;
+
+  if (!workingWeight || workingWeight <= barWeightKg) {
+    return [];
+  }
+
+  const sets: SessionWarmupSetViewModel[] = [];
+
+  for (let i = 0; i < barSets.count; i++) {
+    sets.push({ id: `warmup-${sets.length}`, reps: barSets.reps, weight: barWeightKg });
+  }
+
+  const jump = (workingWeight - barWeightKg) / (rampReps.length + 1);
+  let previousWeight: number = barWeightKg;
+
+  for (let i = 0; i < rampReps.length; i++) {
+    const rawWeight = barWeightKg + (i + 1) * jump;
+    const weight = Math.round(rawWeight / weightStepKg) * weightStepKg;
+
+    if (weight <= previousWeight || weight >= workingWeight) continue;
+
+    sets.push({ id: `warmup-${sets.length}`, reps: rampReps[i], weight });
+    previousWeight = weight;
+  }
+
+  return sets;
+}

--- a/apps/web/src/app/shared/utils/directives/long-press.directive.ts
+++ b/apps/web/src/app/shared/utils/directives/long-press.directive.ts
@@ -58,12 +58,13 @@ export class LongPressDirective implements OnDestroy {
   @Output() txgLongPress = new EventEmitter<PointerEvent>();
 
   /**
-   * Emits the original `PointerEvent` when a tap action is successfully detected.
+   * Emits the original event when a tap action is successfully detected.
    * A tap occurs if the pointer is released before the `txgLongPressDuration` elapses
    * and the movement has not exceeded `txgLongPressMovementThreshold`,
-   * and a long press was not triggered.
+   * and a long press was not triggered. Keyboard activation (Enter/Space on the host,
+   * or an assistive-technology click) also emits, via the synthesized `click` event.
    */
-  @Output() txgClick = new EventEmitter<PointerEvent>();
+  @Output() txgClick = new EventEmitter<MouseEvent>();
 
   private pressTimeout: ReturnType<typeof setTimeout> | null = null;
   private initialX?: number;
@@ -136,6 +137,15 @@ export class LongPressDirective implements OnDestroy {
       }
     }
     this.resetState();
+  }
+
+  @HostListener('click', ['$event'])
+  onClick(event: MouseEvent): void {
+    // Pointer-driven taps are handled in onPointerUp; keyboard (Enter/Space) and
+    // assistive-technology activation dispatch a click with detail === 0 and no pointer
+    // events at all, so without this branch the host is unusable on non-pointer devices.
+    if (event.detail !== 0 || this.txgLongPressDisabled) return;
+    this.txgClick.emit(event);
   }
 
   @HostListener('pointerleave')

--- a/cypress/e2e/sessions/sessions.cy.ts
+++ b/cypress/e2e/sessions/sessions.cy.ts
@@ -71,7 +71,86 @@ describe('Session Tracking', { tags: ['@sessions'] }, () => {
       cy.getBySel(dataCy.sessions.timer).should('contain.text', '00:02');
     });
 
-    it('allows a user to complete a session', { tags: ['SESS-05'] }, () => {
+    it('expands warmup sets from the toggle and dismisses them one by one, without network traffic', { tags: ['SESS-05'] }, () => {
+      cy.intercept(/\/sessions\/[^/]+\/sets/).as('setRequests');
+
+      // Every exercise renders its own toggle before its first working set.
+      cy.getBySel(dataCy.sessions.warmup.toggle).should('have.length', 2);
+      cy.getBySel(dataCy.sessions.warmup.bubble).should('not.exist');
+
+      // Starting Strength even jumps for the first exercise's seeded 100 kg working weight.
+      const expectedWarmups = [
+        { reps: '5', weight: '20' },
+        { reps: '5', weight: '20' },
+        { reps: '5', weight: '40' },
+        { reps: '3', weight: '60' },
+        { reps: '2', weight: '80' },
+      ];
+
+      cy.getBySel(dataCy.sessions.exerciseItem).first().within(() => {
+        cy.getBySel(dataCy.sessions.warmup.toggle).click();
+
+        cy.getBySel(dataCy.sessions.warmup.toggle).should('not.exist');
+        cy.getBySel(dataCy.sessions.warmup.bubble).should('have.length', expectedWarmups.length);
+        expectedWarmups.forEach(({ reps, weight }, i) => {
+          cy.getBySel(dataCy.sessions.warmup.bubbleText).eq(i).should('contain.text', reps);
+          cy.getBySel(dataCy.sessions.warmup.bubbleWeightText).eq(i).should('contain.text', weight);
+        });
+
+        // A single click removes exactly the clicked bubble.
+        cy.getBySel(dataCy.sessions.warmup.bubble).eq(2).click();
+        cy.getBySel(dataCy.sessions.warmup.bubble).should('have.length', expectedWarmups.length - 1);
+        cy.getBySel(dataCy.sessions.warmup.bubbleWeightText).should('not.contain.text', '40');
+
+        // Dismissing the remaining bubbles removes the warmup UI entirely.
+        cy.getBySel(dataCy.sessions.warmup.bubble).each(() => {
+          cy.getBySel(dataCy.sessions.warmup.bubble).first().click();
+        });
+        cy.getBySel(dataCy.sessions.warmup.bubble).should('not.exist');
+        cy.getBySel(dataCy.sessions.warmup.toggle).should('not.exist');
+      });
+
+      // The neighboring exercise's warmup UI is unaffected.
+      cy.getBySel(dataCy.sessions.exerciseItem).eq(1).within(() => {
+        cy.getBySel(dataCy.sessions.warmup.toggle).should('be.visible');
+      });
+
+      // Warmup interactions are ephemeral: no session set requests were issued. Set writes
+      // are debounced by 1s, so outwait the window before asserting silence.
+      cy.getBySel(dataCy.sessions.header.status).should('not.contain.text', 'IN PROGRESS');
+      cy.wait(1100);
+      cy.get('@setRequests.all').should('have.length', 0);
+    });
+
+    it('dismisses the warmup UI when a working set is clicked', { tags: ['SESS-06'] }, () => {
+      cy.intercept(/\/sessions\/[^/]+\/sets\/[^/]+\/complete/).as('completeSet');
+
+      // Expanded case: warmup bubbles disappear on a working set interaction.
+      cy.getBySel(dataCy.sessions.exerciseItem).first().within(() => {
+        cy.getBySel(dataCy.sessions.warmup.toggle).click();
+        cy.getBySel(dataCy.sessions.warmup.bubble).should('have.length.greaterThan', 0);
+        cy.getBySel(dataCy.sessions.set.bubble).first().click();
+        cy.getBySel(dataCy.sessions.warmup.bubble).should('not.exist');
+        cy.getBySel(dataCy.sessions.warmup.toggle).should('not.exist');
+      });
+
+      // The set completion is debounced; let it reach the API before reloading.
+      cy.wait('@completeSet', { requestTimeout: 15000 });
+
+      // The dismissal is per-exercise and survives a reload, because the first exercise is
+      // now mid-workout while the second remains untouched.
+      cy.reload();
+      cy.getBySel(dataCy.sessions.exerciseItem).first().within(() => {
+        cy.getBySel(dataCy.sessions.set.bubble).first().should('have.attr', 'data-cy-set-status', 'COMPLETED');
+        cy.getBySel(dataCy.sessions.warmup.toggle).should('not.exist');
+        cy.getBySel(dataCy.sessions.warmup.bubble).should('not.exist');
+      });
+      cy.getBySel(dataCy.sessions.exerciseItem).eq(1).within(() => {
+        cy.getBySel(dataCy.sessions.warmup.toggle).should('be.visible');
+      });
+    });
+
+    it('allows a user to complete a session', { tags: ['SESS-07'] }, () => {
       cy.getBySel(dataCy.sessions.set.bubble).each((sb: JQuery<HTMLElement>) => cy.wrap(sb).click()); // Complete all sets
       cy.getBySel(dataCy.sessions.set.bubble).filter('[data-cy-set-status="PENDING"]').should('not.exist');
       cy.getBySel(dataCy.sessions.completeButton).click();
@@ -82,7 +161,7 @@ describe('Session Tracking', { tags: ['@sessions'] }, () => {
       cy.getBySel(dataCy.home.sessionCard).should('contain.text', 'Squat: 3x5 @ 102.5 kg'); // Progression rules applied
     });
 
-    it('prompts for confirmation when completing a session with unfinished sets', { tags: ['SESS-06'] }, () => {
+    it('prompts for confirmation when completing a session with unfinished sets', { tags: ['SESS-08'] }, () => {
       cy.getBySel(dataCy.sessions.set.bubble).first().click(); // Complete only one set
       cy.getBySel(dataCy.sessions.set.bubble).filter('[data-cy-set-status="PENDING"]').should('exist');
       cy.getBySel(dataCy.sessions.completeButton).click();
@@ -102,7 +181,7 @@ describe('Session Tracking', { tags: ['@sessions'] }, () => {
       cy.getBySel(dataCy.home.sessionCard).should('contain.text', 'Squat: 3x5 @ 100 kg'); // Progression rules not applied due to incomplete sets
     });
 
-    it('allows a user to add a session note via the notes dialog and see it after reopening', { tags: ['SESS-07'] }, () => {
+    it('allows a user to add a session note via the notes dialog and see it after reopening', { tags: ['SESS-09'] }, () => {
       cy.getBySel(dataCy.sessions.notesButton).click();
       cy.getBySel(dataCy.sessions.dialogs.notes.sessionInput).should('be.focused'); // Let the dialog autofocus settle, or the focus trap steals the keystrokes
       cy.getBySel(dataCy.sessions.dialogs.notes.title).should('be.visible').and('contain.text', 'Notes');
@@ -116,7 +195,7 @@ describe('Session Tracking', { tags: ['@sessions'] }, () => {
       cy.getBySel(dataCy.sessions.dialogs.notes.sessionInput).should('have.value', 'Felt strong on squats today.');
     });
 
-    it('keeps the notes dialog open on a click outside, and discards the edit on Cancel', { tags: ['SESS-08'] }, () => {
+    it('keeps the notes dialog open on a click outside, and discards the edit on Cancel', { tags: ['SESS-10'] }, () => {
       cy.getBySel(dataCy.sessions.notesButton).click();
       cy.getBySel(dataCy.sessions.dialogs.notes.sessionInput).should('be.focused'); // Let the dialog autofocus settle, or the focus trap steals the keystrokes
       cy.getBySel(dataCy.sessions.dialogs.notes.sessionInput).type('Typed then clicked away.');
@@ -134,7 +213,7 @@ describe('Session Tracking', { tags: ['@sessions'] }, () => {
       cy.getBySel(dataCy.sessions.dialogs.notes.sessionInput).should('have.value', ''); // Cancel discarded it
     });
 
-    it('shows the same plan note in other sessions of the same plan', { tags: ['SESS-09'] }, () => {
+    it('shows the same plan note in other sessions of the same plan', { tags: ['SESS-11'] }, () => {
       cy.getBySel(dataCy.sessions.notesButton).click();
       cy.getBySel(dataCy.sessions.dialogs.notes.sessionInput).should('be.focused'); // Let the dialog autofocus settle, or the focus trap steals the keystrokes
       cy.getBySel(dataCy.sessions.dialogs.notes.planInput).type('Switch to low-bar next cycle.');
@@ -155,7 +234,7 @@ describe('Session Tracking', { tags: ['@sessions'] }, () => {
       cy.getBySel(dataCy.sessions.dialogs.notes.sessionInput).should('have.value', ''); // Session notes are per-session
     });
 
-    it('never shows a plan note in a session belonging to a different plan', { tags: ['SESS-10'] }, () => {
+    it('never shows a plan note in a session belonging to a different plan', { tags: ['SESS-12'] }, () => {
       cy.getBySel(dataCy.sessions.notesButton).click();
       cy.getBySel(dataCy.sessions.dialogs.notes.sessionInput).should('be.focused'); // Let the dialog autofocus settle, or the focus trap steals the keystrokes
       cy.getBySel(dataCy.sessions.dialogs.notes.planInput).type('Note for the first plan only.');
@@ -183,7 +262,7 @@ describe('Session Tracking', { tags: ['@sessions'] }, () => {
       cy.getBySel(dataCy.sessions.dialogs.notes.sessionInput).should('have.value', '');
     });
 
-    it('prevents access to another user\'s session notes (RLS check)', { tags: ['SESS-11'] }, () => {
+    it('prevents access to another user\'s session notes (RLS check)', { tags: ['SESS-13'] }, () => {
       let userId1: string;
       let userId2: string;
 

--- a/cypress/support/selectors/sessions/sessions.selectors.ts
+++ b/cypress/support/selectors/sessions/sessions.selectors.ts
@@ -10,6 +10,12 @@ export const sessionsSelectors = {
     bubbleText: 'set-bubble-text',
     bubbleWeightText: 'set-bubble-weight-text',
   },
+  warmup: {
+    toggle: 'warmup-toggle-bubble',
+    bubble: 'warmup-set-bubble',
+    bubbleText: 'warmup-set-bubble-text',
+    bubbleWeightText: 'warmup-set-bubble-weight-text',
+  },
   dialogs: {
     sets: {
       title: 'add-edit-set-dialog-title',
@@ -31,6 +37,7 @@ export const sessionsSelectors = {
     navigateButton: 'session-card-navigate-button',
     notesButton: 'session-card-notes-button',
   },
+  exerciseItem: 'session-exercise-item',
   timer: 'session-timer',
   completeButton: 'complete-session-button',
   notesButton: 'session-notes-button',

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -146,13 +146,15 @@ This is a non-exhaustive list of high-priority test scenarios. Tests marked "Yes
 | | SESS-02 | A user can tap a set bubble to cycle through its states (Pending -> Completed -> Failed -> Pending). | Critical | No |
 | | SESS-03 | A user can long-press a set bubble to open the edit dialog and successfully update its details. | High | No |
 | | SESS-04 | The session timer starts and updates correctly after the first set interaction. | Critical | No |
-| | SESS-05 | A user can successfully complete a session, after which a new session is available and they are redirected. | Critical | No |
-| | SESS-06 | A user is prompted with a confirmation dialog if they try to complete a session with unfinished sets. | High | No |
-| | SESS-07 | A user can open the notes dialog via the FAB in the session view, enter a session note, close the dialog with 'Save', and see the note again after reopening. | High | No |
-| | SESS-08 | The notes dialog is modal: a click outside neither closes it nor saves, and 'Cancel' discards the entered text. | High | No |
-| | SESS-09 | A plan note entered in one session is displayed when the notes dialog is opened in another session of the same plan. | High | No |
-| | SESS-10 | A plan note from one plan is never displayed in a session belonging to a different plan. | Critical | No |
-| | SESS-11 | A user cannot read or modify another user's notes (RLS check). | Critical | No |
+| | SESS-05 | A user can expand ephemeral warmup sets from the warmup toggle and dismiss them one by one, without any network traffic. | Medium | No |
+| | SESS-06 | Clicking a working set dismisses that exercise's warmup UI, and the dismissal persists per exercise across a reload. | Medium | No |
+| | SESS-07 | A user can successfully complete a session, after which a new session is available and they are redirected. | Critical | No |
+| | SESS-08 | A user is prompted with a confirmation dialog if they try to complete a session with unfinished sets. | High | No |
+| | SESS-09 | A user can open the notes dialog via the FAB in the session view, enter a session note, close the dialog with 'Save', and see the note again after reopening. | High | No |
+| | SESS-10 | The notes dialog is modal: a click outside neither closes it nor saves, and 'Cancel' discards the entered text. | High | No |
+| | SESS-11 | A plan note entered in one session is displayed when the notes dialog is opened in another session of the same plan. | High | No |
+| | SESS-12 | A plan note from one plan is never displayed in a session belonging to a different plan. | Critical | No |
+| | SESS-13 | A user cannot read or modify another user's notes (RLS check). | Critical | No |
 | **History** | HIST-01 | A completed session correctly appears in the session history list. | High | No |
 | | HIST-02 | The session history list correctly paginates when there are more sessions than the page size. | Medium | No |
 | | HIST-03 | A user can open the filter dialog and apply filters for date range, verifying the results. | Medium | No |


### PR DESCRIPTION
## Summary

Adds an ephemeral warmup UI to the session page: each exercise with only pending sets shows a `W` toggle bubble that expands into computed warmup set bubbles, rendered in the same form factor as working set bubbles but visually distinct (dashed border, secondary color).

- **Warmup calculation**: Starting Strength "even jumps" — 2×5 with the empty bar (20 kg), then three ramp sets at even quarters of the gap to the working weight (reps 5/3/2), rounded to 2.5 kg; non-increasing or at-working-weight sets are dropped. The working weight is the exercise's top set. Barbell-only assumption for now (#51).
- **Ephemeral by design**: nothing is persisted — a click dismisses a single warmup bubble, tapping any working set dismisses the exercise's whole warmup UI, and no network requests are issued. State is derived (`computed`) from the exercise viewmodel, so optimistic updates and failure reverts handle the warmup UI automatically.
- **Interactions**: warmup bubbles use the shared `txgLongPress`/`txgClick` directive to avoid a pointer/native-click retargeting race; the directive also gained keyboard/AT click support. Enter-only animation (respects `prefers-reduced-motion`).
- **Dev container**: `post-start.sh` now starts Xvfb so headless Cypress runs work out of the box under WSL's dead `DISPLAY`.
- **Tests**: unit tests for the warmup calculator and all three session-page components; the sessions e2e suite gained warmup coverage and was renumbered into logical lifecycle order (SESS-01–13), with `docs/test-plan.md` updated to match.

## Test plan

- [x] `pnpm --filter @txg/web lint` clean
- [x] 347/347 unit tests pass
- [x] Sessions e2e suite passes 13/13 against the local stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)