### PR TITLE
fix(progress): Paginate the progress query and unbound the range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,9 +55,9 @@ coverage/
 testem.log
 /typings
 
-# Draft documents (work-in-progress specs, notes)
-docs/drafts/*
-!docs/drafts/.gitkeep
+# Spec documents
+docs/specs/*
+!docs/specs/.gitkeep
 
 # Environment files
 .env

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1532,11 +1532,13 @@ For every `(exercise, session)` pair:
 
 Sessions whose status is not `COMPLETED` are excluded entirely, and a pair with no completed set yields no point. Series are sorted by exercise name, points by `session_date` ascending. The response is not paginated — one point per exercise per session keeps it small regardless of set count — so no `totalCount` is returned.
 
+The underlying read *is* paginated internally. PostgREST caps any single response at `max_rows` (1000), which a consistent lifter crosses at roughly six months of history, so the repository walks the matching sets a page at a time and aggregates the complete set. Without a `date_from` this spans the account's entire history; the request is correspondingly slower for a long-lived account, and a query needing more than 25 pages (25,000 sets) is rejected with a `500` rather than silently returning a partial series.
+
 -   **Authorization**: Bearer token required.
 -   **URL Query Parameters**:
     -   `plan_id` (optional, string UUID): Restrict to sessions of a single plan. Omit to span all of the user's plans.
     -   `exercise_ids` (optional, comma-separated UUIDs): Restrict the returned series to these exercises.
-    -   `date_from` (optional, string ISO 8601): Filter sessions from this date (inclusive). Rejected with `400 Bad Request` if later than `date_to`.
+    -   `date_from` (optional, string ISO 8601): Filter sessions from this date (inclusive). Omit to span the user's entire history — this is what the client's `ALL` range sends. Rejected with `400 Bad Request` if later than `date_to`.
     -   `date_to` (optional, string ISO 8601): Filter sessions up to this date (inclusive).
 -   **Response (200 OK)**: An array of `ExerciseProgressDto` objects.
     ```json

--- a/apps/api/src/repositories/progress.repository.ts
+++ b/apps/api/src/repositories/progress.repository.ts
@@ -1,7 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { Database } from '@txg/shared';
 import type { ExerciseProgressDto } from '@txg/shared';
-import { aggregateExerciseProgress, resolveProgressWindowStart } from '../services/exercise-progress/exercise-progress';
+import { aggregateExerciseProgress } from '../services/exercise-progress/exercise-progress';
 import type { ExerciseProgressRow } from '../services/exercise-progress/exercise-progress';
 
 export interface ExerciseProgressQueryOptions {
@@ -10,6 +10,25 @@ export interface ExerciseProgressQueryOptions {
   date_from?: string;
   date_to?: string;
 }
+
+/**
+ * How many set rows one progress page requests.
+ *
+ * PostgREST caps every response at `max_rows` (1000, see `supabase/config.toml`) and reports the
+ * true total only in a header, so a query matching more rows is silently truncated. Matching the
+ * page size to that cap means a full page is the signal that more rows remain.
+ */
+const PROGRESS_PAGE_SIZE = 1000;
+
+/**
+ * The ceiling on how many pages one progress query may walk.
+ *
+ * At ~39 sets/week for a consistent lifter this covers well over a decade of training, so it is
+ * not reachable by ordinary use. It exists so a pathological account cannot spin the request
+ * indefinitely - and it throws rather than returning what it has, because silently returning a
+ * partial series is the exact defect this pagination removes.
+ */
+const MAX_PROGRESS_PAGES = 25;
 
 export class ProgressRepository {
   constructor(
@@ -21,10 +40,45 @@ export class ProgressRepository {
    * Finds per-exercise progress series built from the sets of the user's completed
    * sessions, optionally narrowed by plan, exercises and date range.
    *
+   * Reads the matching sets a page at a time, because a consistent lifter crosses PostgREST's
+   * 1000-row cap at roughly six months of history and the truncation is otherwise invisible.
+   * Omitting `date_from` means all history, so this walks as many pages as the account needs.
+   *
    * @param {ExerciseProgressQueryOptions} options - The query options for filtering.
    * @returns {Promise<ExerciseProgressDto[]>} A promise that resolves to the aggregated series.
    */
   async findExerciseProgress(options: ExerciseProgressQueryOptions): Promise<ExerciseProgressDto[]> {
+    const rows: ExerciseProgressRow[] = [];
+
+    for (let page = 0; page < MAX_PROGRESS_PAGES; page++) {
+      const pageRows = await this.findExerciseProgressPage(options, page);
+      rows.push(...pageRows);
+
+      if (pageRows.length < PROGRESS_PAGE_SIZE) {
+        return aggregateExerciseProgress(rows);
+      }
+    }
+
+    throw new Error(
+      `Exercise progress query exceeded ${MAX_PROGRESS_PAGES} pages of ${PROGRESS_PAGE_SIZE} sets. ` +
+      'Narrow the date range.'
+    );
+  }
+
+  /**
+   * Reads a single page of the progress query.
+   *
+   * Ordered by `id` so page boundaries are stable: without a total order PostgREST returns rows
+   * in planner order, and the same row can appear on two pages or on none.
+   *
+   * @param {ExerciseProgressQueryOptions} options - The query options for filtering.
+   * @param {number} page - The zero-based page index to read.
+   * @returns {Promise<ExerciseProgressRow[]>} A promise that resolves to the page's set rows.
+   */
+  private async findExerciseProgressPage(
+    options: ExerciseProgressQueryOptions,
+    page: number
+  ): Promise<ExerciseProgressRow[]> {
     let supabaseQuery = this.supabase
       .from('session_sets')
       .select(`
@@ -47,11 +101,18 @@ export class ProgressRepository {
       supabaseQuery = supabaseQuery.in('plan_exercise.exercise_id', options.exercise_ids);
     }
 
-    supabaseQuery = supabaseQuery.gte('session.session_date', resolveProgressWindowStart(options.date_from));
+    if (options.date_from) {
+      supabaseQuery = supabaseQuery.gte('session.session_date', options.date_from);
+    }
 
     if (options.date_to) {
       supabaseQuery = supabaseQuery.lte('session.session_date', options.date_to);
     }
+
+    const offset = page * PROGRESS_PAGE_SIZE;
+    supabaseQuery = supabaseQuery
+      .order('id', { ascending: true })
+      .range(offset, offset + PROGRESS_PAGE_SIZE - 1);
 
     const { data, error } = await supabaseQuery;
 
@@ -59,7 +120,7 @@ export class ProgressRepository {
       throw error;
     }
 
-    return aggregateExerciseProgress((data ?? []) as unknown as ExerciseProgressRow[]);
+    return (data ?? []) as unknown as ExerciseProgressRow[];
   }
 
 }

--- a/apps/api/src/services/exercise-progress/exercise-progress.spec.ts
+++ b/apps/api/src/services/exercise-progress/exercise-progress.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { DEFAULT_PROGRESS_WINDOW_MONTHS, aggregateExerciseProgress, resolveProgressWindowStart } from './exercise-progress';
+import { aggregateExerciseProgress } from './exercise-progress';
 import type { ExerciseProgressRow } from './exercise-progress';
 
 const SQUAT_ID = '2a7b3d4f-0c5e-4f9a-b2c3-d4e5f6a7b8c9';
@@ -175,29 +175,45 @@ describe('aggregateExerciseProgress', () => {
 
     expect(result[0].points.map(p => p.plan_id)).toEqual([PLAN_ID, otherPlanId]);
   });
-});
 
-describe('resolveProgressWindowStart', () => {
-  const NOW = new Date('2026-07-20T12:00:00.000Z');
+  it('should aggregate a session whose sets arrive split across page boundaries', () => {
+    // The repository reads sets a page at a time and concatenates them. A session straddling a
+    // boundary must still yield one point carrying every set - a half-arrived session that
+    // produces a short `reps` array and an understated top weight is the defect pagination fixes,
+    // and it renders as a legitimate point rather than a missing one.
+    const pageOne = [
+      makeRow({ weight: 100, setIndex: 1, reps: 5 }),
+      makeRow({ weight: 100, setIndex: 2, reps: 5 }),
+      makeRow({ weight: 100, setIndex: 3, reps: 5 }),
+    ];
+    const pageTwo = [
+      makeRow({ weight: 120, setIndex: 4, reps: 3 }),
+      makeRow({ weight: 100, setIndex: 5, reps: 4, status: 'FAILED' }),
+    ];
 
-  it('should use the start date the caller asked for', () => {
-    expect(resolveProgressWindowStart('2020-01-01T00:00:00.000Z', NOW)).toBe('2020-01-01T00:00:00.000Z');
+    const result = aggregateExerciseProgress([...pageOne, ...pageTwo]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].points).toHaveLength(1);
+    expect(result[0].points[0].top_weight).toBe(120);
+    expect(result[0].points[0].reps).toEqual([5, 5, 5, 3, 4]);
   });
 
-  it('should default to a bounded window rather than the whole training history', () => {
-    // Without a floor the query reads every set of every completed session ever recorded, and
-    // aggregates them in the API process - a cost that grows with the age of the account.
-    expect(resolveProgressWindowStart(undefined, NOW)).toBe('2025-07-20T12:00:00.000Z');
-  });
+  it('should place a session on one point regardless of how pages interleave sessions', () => {
+    // Pages are ordered by set id, not by session, so one page can carry the tail of one session
+    // and the head of the next.
+    const pageOne = [
+      makeRow({ sessionId: SESSION_A, sessionDate: '2026-04-15T17:32:11.000Z', weight: 100, setIndex: 1 }),
+      makeRow({ sessionId: SESSION_B, sessionDate: '2026-04-22T18:01:47.000Z', weight: 105, setIndex: 1 }),
+    ];
+    const pageTwo = [
+      makeRow({ sessionId: SESSION_A, sessionDate: '2026-04-15T17:32:11.000Z', weight: 102, setIndex: 2 }),
+      makeRow({ sessionId: SESSION_B, sessionDate: '2026-04-22T18:01:47.000Z', weight: 107, setIndex: 2 }),
+    ];
 
-  it('should place the default window exactly DEFAULT_PROGRESS_WINDOW_MONTHS back', () => {
-    const start = new Date(resolveProgressWindowStart(undefined, NOW));
-    const monthsBack = (NOW.getUTCFullYear() - start.getUTCFullYear()) * 12 + (NOW.getUTCMonth() - start.getUTCMonth());
+    const result = aggregateExerciseProgress([...pageOne, ...pageTwo]);
 
-    expect(monthsBack).toBe(DEFAULT_PROGRESS_WINDOW_MONTHS);
-  });
-
-  it('should roll the year back correctly from early January', () => {
-    expect(resolveProgressWindowStart(undefined, new Date('2026-01-05T00:00:00.000Z'))).toBe('2025-01-05T00:00:00.000Z');
+    expect(result[0].points).toHaveLength(2);
+    expect(result[0].points.map(p => p.top_weight)).toEqual([102, 107]);
   });
 });

--- a/apps/api/src/services/exercise-progress/exercise-progress.ts
+++ b/apps/api/src/services/exercise-progress/exercise-progress.ts
@@ -25,37 +25,6 @@ export interface ExerciseProgressRow {
 }
 
 /**
- * How far back progress reaches when the caller asks for no start date.
- *
- * Long enough to cover a year of training at a glance, which is more than any chart in the app
- * shows by default.
- */
-export const DEFAULT_PROGRESS_WINDOW_MONTHS = 12;
-
-/**
- * Resolves the start of the window a progress query should cover.
- *
- * Without a floor this query reads every set of every completed session the user has ever
- * recorded, and aggregates them in the API process. That cost grows with the age of the account
- * for a chart that never plots most of it, so an unbounded request gets a default window rather
- * than the user's whole history.
- *
- * @param {string | undefined} dateFrom - The start date the caller asked for, if any.
- * @param {Date} now - The current instant, injected so the default is testable.
- * @returns {string} The ISO start date to filter on.
- */
-export function resolveProgressWindowStart(dateFrom: string | undefined, now: Date = new Date()): string {
-  if (dateFrom) {
-    return dateFrom;
-  }
-
-  const start = new Date(now);
-  start.setUTCMonth(start.getUTCMonth() - DEFAULT_PROGRESS_WINDOW_MONTHS);
-
-  return start.toISOString();
-}
-
-/**
  * Aggregates the sets of completed sessions into per-exercise progress series.
  *
  * For every (exercise, session) pair one point is produced, carrying:

--- a/apps/web/src/app/features/history/pages/history-page/components/history-actions-bar/history-actions-bar.component.ts
+++ b/apps/web/src/app/features/history/pages/history-page/components/history-actions-bar/history-actions-bar.component.ts
@@ -27,8 +27,8 @@ export class HistoryActionsBarComponent {
   @Input() pageSize: number = 10;
   @Input() pageIndex: number = 0;
   @Input() pageSizeOptions: number[] = [5, 10, 25, 100];
-  @Input() viewMode: HistoryViewMode = 'list';
   @Input() planName: string = '';
+  @Input() viewMode: HistoryViewMode = 'list';
 
   @Output() filterButtonClicked = new EventEmitter<void>();
   @Output() pageChanged = new EventEmitter<PageEvent>();


### PR DESCRIPTION
## Summary

The progress chart silently dropped data once a user accumulated more than 1000 `session_sets` rows within the selected filters. This paginates the read and, with the row cap no longer forcing a bounded window, lets the `ALL` date range actually mean all history.

## The defect

`findExerciseProgress` issued a single unbounded `session_sets` query. PostgREST caps every response at `max_rows` (1000, `supabase/config.toml:18`) and reports the true total only in the `Content-Range` header — **it does not error**. Nothing in the path could distinguish "1000 rows matched" from "1000 of N matched", so the truncation was invisible to the API, the client, and the user.

A consistent lifter on a StrongLifts 5x5 plan averages ~39 sets/week, crossing the cap at roughly six months of history. Two failures followed:

1. **Missing days** — a session whose sets were all cut yielded no point, so the day vanished from the chart.
2. **Silently incorrect points** — a session that arrived *partially* still produced a point, with `top_weight` derived only from the surviving `COMPLETED` sets and a short tooltip `reps` array. Those rendered as legitimate while being wrong.

Which days were lost was not deterministic: the query carried no `order by`, so PostgREST returned planner order and the loss looked scattered rather than cleanly truncated at one end — which is what made this hard to spot from the UI.

## The fix

- **Paginate the read.** `findExerciseProgress` now loops `.range()` until a short page returns, handing the complete set to the existing `aggregateExerciseProgress`. Query building moved into a private `findExerciseProgressPage`, rebuilt per page — awaiting a `PostgrestFilterBuilder` executes it, so reusing one across pages would be wrong.
- **`.order('id')` on every page.** Without a total order, page boundaries are unstable and a row can land on two pages or none. This is load-bearing, not cosmetic.
- **Drop the 12-month default window.** `resolveProgressWindowStart` (added in #56 to bound an unbounded read) silently floored any request without a `date_from` at 12 months — and the `ALL` preset is exactly the case that sends no `date_from`, so `ALL` and `1Y` were the same query. The pagination loop's 25-page ceiling now serves the original purpose, and it **throws** on reaching it rather than returning a partial series: failing loudly beats reintroducing this defect at a higher threshold.

No web changes were needed — `presetToRange('ALL')` already returned null bounds and the facade already omitted the parameter, so `ALL` started meaning all the moment the server stopped flooring it.

## Testing

| Suite | Result |
|---|---|
| `pnpm lint` (4 packages, eslint + tsc) | clean |
| `pnpm test` | 654 passed (198 API, 456 web) |
| `pnpm e2e:run` | 62/62 passed |

Added two page-boundary cases to `exercise-progress.spec.ts`: one session's sets split across pages must still yield a single point with the full `reps` array and true top weight (the silent-corruption case above), and interleaved sessions across pages must still collapse to one point each. Removed the four `resolveProgressWindowStart` cases along with the function.

Repository pagination itself is not unit tested, per `apps/api/CLAUDE.md` — repositories are covered by Cypress against a real database. A Cypress case seeding >1000 sets is **not** included here and would be a reasonable follow-up.

## Notes for the reviewer

- **Latency is a deliberate trade.** `ALL` on a multi-year account now reads every set row to plot ~350 points. Pagination makes that *correct*, not *cheap*. The thing that makes it cheap is a Postgres RPC aggregating one row per `(exercise, session)` — ~15x fewer rows — which was considered and deferred, since it relocates logic `apps/api/CLAUDE.md` deliberately keeps in `services/` and needs a migration plus an aggregation-test rewrite. Worth doing if this endpoint becomes a performance concern.
- **Sequential, not parallel.** A `count: 'exact'` + `Promise.all` variant was considered and dropped: it needs a second code path for a null `count` that can't be exercised in a unit test, and if that branch were ever wrong it would silently truncate — the exact bug being fixed.
- **Known edge:** an account with *exactly* 25,000 matching sets would throw despite having no further rows. Left as-is; no user is near that size.
- The other two commits are unrelated working-tree changes bundled at the author's request: the git-ignored `docs/drafts` → `docs/specs` rename, and an `@Input` reorder in the history actions bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
